### PR TITLE
Added option to only Scrobble Primary Artist

### DIFF
--- a/AMWin-RichPresence/App.config
+++ b/AMWin-RichPresence/App.config
@@ -25,6 +25,9 @@
             <setting name="ShowAppleMusicIcon" serializeAs="String">
                 <value>True</value>
             </setting>
+            <setting name="scrobbleOnlyPrimary" serializeAs="String">
+                <value>False</value>
+            </setting>
         </AMWin_RichPresence.Properties.Settings>
     </userSettings>
 </configuration>

--- a/AMWin-RichPresence/AppleMusicScrobbler.cs
+++ b/AMWin-RichPresence/AppleMusicScrobbler.cs
@@ -22,6 +22,10 @@ namespace AMWin_RichPresence
         private string? lastSongID;
         private bool hasScrobbled;
 
+        //for personal use not sure if better way of doing this
+        string[] exemptArtists = {"Tyler, The Creator", "nothing,nowhere."};
+
+
 
         public async void init(bool showMessageBoxOnSuccess = false)
         {
@@ -89,6 +93,14 @@ namespace AMWin_RichPresence
                     {
                         if (lastfmAuth != null && lastfmAuth.Authenticated)
                         {
+                            if (AMWin_RichPresence.Properties.Settings.Default.scrobbleOnlyPrimary == true && !exemptArtists.Contains(info.SongArtist))
+                            {
+                                //todo exemptions for artists containing & or comma (not exactly sure if possible without manually enetering artist names)
+                                string[] artists = info.SongArtist.Split('&', ',');
+                                string primaryArtist = artists[0].Trim();
+                                info.SongArtist = primaryArtist;
+                            }
+                            
                             Trace.WriteLine(string.Format("{0} LastFM Scrobbler - Scrobbling: {1}", DateTime.UtcNow.ToString(), lastSongID));
                             var scrobble = new Scrobble(info.SongArtist, info.SongAlbum, info.SongName, DateTime.UtcNow);
                             var response = await lastFmScrobbler.ScrobbleAsync(scrobble);

--- a/AMWin-RichPresence/Properties/Settings.Designer.cs
+++ b/AMWin-RichPresence/Properties/Settings.Designer.cs
@@ -94,5 +94,17 @@ namespace AMWin_RichPresence.Properties {
                 this["ShowAppleMusicIcon"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool scrobbleOnlyPrimary {
+            get {
+                return ((bool)(this["scrobbleOnlyPrimary"]));
+            }
+            set {
+                this["scrobbleOnlyPrimary"] = value;
+            }
+        }
     }
 }

--- a/AMWin-RichPresence/Properties/Settings.settings
+++ b/AMWin-RichPresence/Properties/Settings.settings
@@ -20,5 +20,8 @@
     <Setting Name="ShowAppleMusicIcon" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="scrobbleOnlyPrimary" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/AMWin-RichPresence/SettingsWindow.xaml
+++ b/AMWin-RichPresence/SettingsWindow.xaml
@@ -7,7 +7,7 @@
         xmlns:properties="clr-namespace:AMWin_RichPresence.Properties"
         mc:Ignorable="d"
         Icon="/Resources/AppleMusicTray.ico"
-        Title="AMWin-RichPresence" Height="360" Width="440" ResizeMode="NoResize" WindowStartupLocation="CenterScreen">
+        Title="AMWin-RichPresence" Height="400" Width="450" ResizeMode="NoResize" WindowStartupLocation="CenterScreen">
     <Grid Background="{DynamicResource {x:Static SystemColors.ControlBrushKey}}">
         <DockPanel>
             <Border DockPanel.Dock="Top" Height="64" Padding="10" Background="{DynamicResource {x:Static SystemColors.ControlLightBrushKey}}" BorderBrush="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}" BorderThickness="0 0 0 1.5">
@@ -19,9 +19,9 @@
                     </StackPanel>
                 </StackPanel>
             </Border>
-            <Border Padding="15" Background="{DynamicResource {x:Static SystemColors.ControlBrushKey}}">
+            <Border Padding="15" Background="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" Height="307">
                 <StackPanel Orientation="Vertical">
-                    <Grid>
+                    <Grid Height="250" Width="408">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="150"/>
                             <ColumnDefinition Width="120"/>
@@ -62,8 +62,10 @@
                         <TextBox Grid.Row="6" Grid.Column="1" x:Name="LastfmUsername" Text="{Binding Source={x:Static properties:Settings.Default}, Path=Default.LastfmUsername}" TextWrapping="Wrap" Margin="0,0,-121,0" VerticalAlignment="Center"/>
                         <TextBlock Grid.Row="7" Grid.Column="0" VerticalAlignment="Center" Padding="10 0 0 0">Password</TextBlock>
                         <PasswordBox Grid.Row="7" Grid.Column="1" x:Name="LastfmPassword" VerticalAlignment="Center" Margin="0,0,-121,0"/>
-                        <Button Grid.Row="8" Grid.Column="1" Content="Button" HorizontalAlignment="Left" Margin="201,10,0,0" VerticalAlignment="Top" Width="0"/>
-                        <Button Grid.Row="8" Grid.Column="1" x:Name="SaveLastFMCreds" Content="Save Last.FM Credentials" VerticalAlignment="Center" Margin="99,0,-121,0" Click="SaveLastFMCreds_Click"/>
+                        <TextBlock Grid.Row="8" Grid.Column="0" Margin="10,2,17,3" Grid.ColumnSpan="2">Scrobble only Primary Artist (EXPERIMENTAL)</TextBlock>
+                        <CheckBox Grid.Row="9" x:Name="CheckBox_scrobblePimaryOnly" Margin="103,2,-103,0" IsChecked="{Binding Source={x:Static properties:Settings.Default}, Path=scrobbleOnlyPrimary, Mode=TwoWay}" Click="CheckBox_ScrobblePimaryOnly_Click" Grid.Column="1"/>
+                        <Button Grid.Row="9" Grid.Column="1" Content="Button" HorizontalAlignment="Left" Margin="201,10,0,0" VerticalAlignment="Top" Width="0"/>
+                        <Button Grid.Row="10" Grid.Column="1" x:Name="SaveLastFMCreds" Content="Save Last.FM Credentials" Margin="103,25,-125,-20" Click="SaveLastFMCreds_Click"/>
                     </Grid>
                 </StackPanel>
             </Border>

--- a/AMWin-RichPresence/SettingsWindow.xaml
+++ b/AMWin-RichPresence/SettingsWindow.xaml
@@ -51,9 +51,7 @@
                             <ComboBoxItem>Artist only</ComboBoxItem>
                             <ComboBoxItem>Album only</ComboBoxItem>
                         </ComboBox>
-
-                        <TextBlock Grid.Row="3" VerticalAlignment="Center" FontWeight="Bold" Padding="0 3 0 0">Last.FM settings</TextBlock>
-
+                        <TextBlock Grid.Row="3" VerticalAlignment="Center" FontWeight="Bold" Padding="0 3 0 0">Last.FM Settings</TextBlock>
                         <TextBlock Grid.Row="4" Grid.Column="0" VerticalAlignment="Center" Padding="10 0 0 0">API Key</TextBlock>
                         <TextBox Grid.Row="4" Grid.Column="1" x:Name="LastfmAPIKey" Text="{Binding Source={x:Static properties:Settings.Default}, Path=Default.LastfmAPIKey}" TextWrapping="Wrap" Margin="0,0,-121,0" FontFamily="Lucida Sans Typewriter" VerticalAlignment="Center"/>
                         <TextBlock Grid.Row="5" Grid.Column="0" VerticalAlignment="Center" Padding="10 0 0 0">API Secret</TextBlock>

--- a/AMWin-RichPresence/SettingsWindow.xaml.cs
+++ b/AMWin-RichPresence/SettingsWindow.xaml.cs
@@ -33,7 +33,6 @@ namespace AMWin_RichPresence {
         private void CheckBox_ShowAppleMusicIcon_Click(object sender, RoutedEventArgs e)
         {
             SaveSettings();
-      
         }
 
         private void CheckBox_ScrobblePimaryOnly_Click(object sender, RoutedEventArgs e)

--- a/AMWin-RichPresence/SettingsWindow.xaml.cs
+++ b/AMWin-RichPresence/SettingsWindow.xaml.cs
@@ -30,11 +30,19 @@ namespace AMWin_RichPresence {
             SaveSettings();
         }
 
-        private void CheckBox_ShowAppleMusicIcon_Click(object sender, RoutedEventArgs e) {
+        private void CheckBox_ShowAppleMusicIcon_Click(object sender, RoutedEventArgs e)
+        {
+            SaveSettings();
+      
+        }
+
+        private void CheckBox_ScrobblePimaryOnly_Click(object sender, RoutedEventArgs e)
+        {
             SaveSettings();
         }
 
-        private void ComboBox_RPSubtitleChoice_SelectionChanged(object sender, SelectionChangedEventArgs e) {
+
+            private void ComboBox_RPSubtitleChoice_SelectionChanged(object sender, SelectionChangedEventArgs e) {
             var newOption = AppleMusicDiscordClient.SubtitleOptionFromIndex(ComboBox_RPSubtitleChoice.SelectedIndex);
             ((App)Application.Current).UpdateRPSubtitleDisplay(newOption);
 


### PR DESCRIPTION
This is done by splitting Artists based on `&` or  `,`
I have also added an Array to place artists names that conain these symbols in their name to avoid them.
This is not the best way to do it but I don't think anything else is possible for now unless there is some way to acess the Album Artist Field (not shown in now playing atm) or maybe if Apple updates the App we will actually be able to get the individual artists attached to the song.

So yeah bit of a hacky approach so don't really expect a merge but not sure if any other way to do it and I am sick of editing manually. I plan to do more work on this on my fork and remove all the discord stuff in the future anyway. 