### PR TITLE
Modify largeImageText to line up with Spotify

### DIFF
--- a/AMWin-RichPresence/AppleMusicDiscordClient.cs
+++ b/AMWin-RichPresence/AppleMusicDiscordClient.cs
@@ -71,7 +71,7 @@ internal class AppleMusicDiscordClient {
                 State = subtitle,
                 Assets = new Assets() {
                     LargeImageKey = amInfo.CoverArtUrl ?? Constants.DiscordAppleMusicImageKey,
-                    LargeImageText = songName
+                    LargeImageText = songAlbum
                 }
             };
 


### PR DESCRIPTION
LargeImageText should show the Album name, not Song name. This also fixes integration with my Vencord plugin to show the discord status as "Listening to Apple Music". This makes the status completely identical to the official spotify one. (The vencord plugin isn't officially available in the app yet)