### PR TITLE
using lastfm suggested scrobble time

### DIFF
--- a/AMWin-RichPresence/AppleMusicScrobbler.cs
+++ b/AMWin-RichPresence/AppleMusicScrobbler.cs
@@ -94,7 +94,7 @@ namespace AMWin_RichPresence
                 else
                 {
                     elapsedSeconds += Constants.RefreshPeriod;
-                    if (elapsedSeconds > Constants.LastFMTimeBeforeScrobbling && !hasScrobbled)
+                    if (IsTimeToScrobble(info, elapsedSeconds) && !hasScrobbled)
                     {
                         if (lastfmAuth != null && lastfmAuth.Authenticated)
                         {
@@ -118,6 +118,14 @@ namespace AMWin_RichPresence
             }
         }
 
+        private bool IsTimeToScrobble(AppleMusicInfo info, int elapsedSeconds)
+        {
+            if (info.SongDuration.HasValue && info.SongDuration.Value >= 30 ) { // we should only scrobble tracks with more than 30 seconds
+                double halfSongDuration = info.SongDuration.Value / 2;
+                return elapsedSeconds >= halfSongDuration || elapsedSeconds >= 240; // half the song has passed or more that 4 minutes
+            }
+            return elapsedSeconds > Constants.LastFMTimeBeforeScrobbling;
+        }
 
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/PKBeam/AMWin-RP/issues/5
Scrobbling at half the song duration, or 4 minutes. Also, limits scrobbles to tracks with at least 30 seconds