### PR TITLE
 feat: Send listens to ListenBrainz (#17)

### DIFF
--- a/AMWin-RichPresence/AMWin-RichPresence.csproj
+++ b/AMWin-RichPresence/AMWin-RichPresence.csproj
@@ -8,7 +8,8 @@
     <UseWPF>true</UseWPF>
     <ApplicationIcon>Resources\AMWinRP.ico</ApplicationIcon>
     <AssemblyVersion>1.0</AssemblyVersion>
-    <FileVersion>1.2.6.3</FileVersion>
+    <FileVersion>1.3.0</FileVersion>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
 
   <ItemGroup>
@@ -21,6 +22,7 @@
     <PackageReference Include="Hardcodet.NotifyIcon.Wpf" Version="1.1.0" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.46" />
     <PackageReference Include="Inflatable.Lastfm" Version="1.2.0" />
+    <PackageReference Include="MetaBrainz.ListenBrainz" Version="4.0.0" />
     <PackageReference Include="SecureCredentialManagement" Version="1.0.2" />
   </ItemGroup>
 

--- a/AMWin-RichPresence/App.config
+++ b/AMWin-RichPresence/App.config
@@ -22,6 +22,9 @@
             <setting name="LastfmUsername" serializeAs="String">
                 <value />
             </setting>
+            <setting name="ListenBrainzUserToken" serializeAs="String">
+                <value />
+            </setting>
             <setting name="ShowAppleMusicIcon" serializeAs="String">
                 <value>True</value>
             </setting>
@@ -35,6 +38,9 @@
                 <value>False</value>
             </setting>
             <setting name="LastfmEnable" serializeAs="String">
+                <value>True</value>
+            </setting>
+            <setting name="ListenBrainzEnable" serializeAs="String">
                 <value>True</value>
             </setting>
             <setting name="ShowRPWhenMusicPaused" serializeAs="String">

--- a/AMWin-RichPresence/AppleMusicClientScraper.cs
+++ b/AMWin-RichPresence/AppleMusicClientScraper.cs
@@ -11,17 +11,17 @@ namespace AMWin_RichPresence {
     internal class AppleMusicInfo {
         // the following fields are only valid if HasSong is true.
         // DateTimes are in UTC.
-        public string        SongName;
-        public string        SongSubTitle;
-        public string        SongAlbum;
-        public string        SongArtist;
-        public bool          IsPaused = true;
-        public DateTime?     PlaybackStart;
-        public DateTime?     PlaybackEnd;
-        public int?          SongDuration = null;
+        public string SongName;
+        public string SongSubTitle;
+        public string SongAlbum;
+        public string SongArtist;
+        public bool IsPaused = true;
+        public DateTime? PlaybackStart;
+        public DateTime? PlaybackEnd;
+        public int? SongDuration = null;
         public List<string>? ArtistList = null;
-        public string?       CoverArtUrl = null;
-        public int?          CurrentTime = null;
+        public string? CoverArtUrl = null;
+        public int? CurrentTime = null;
 
         public AppleMusicInfo(string songName, string songSubTitle, string songAlbum, string songArtist) {
             this.SongName = songName;
@@ -119,7 +119,7 @@ namespace AMWin_RichPresence {
             }
 
             var songFields = amWinLCD
-                .FindAll  (TreeScope.Children, new PropertyCondition(AutomationElement.AutomationIdProperty, "myScrollViewer"));
+                .FindAll(TreeScope.Children, new PropertyCondition(AutomationElement.AutomationIdProperty, "myScrollViewer"));
 
             // ================================================
             //  Check if there is a song playing
@@ -151,7 +151,7 @@ namespace AMWin_RichPresence {
 
             // some classical songs add "By " before the composer's name
             string? songComposer = null;
-            string? songPerformer = null; 
+            string? songPerformer = null;
             var composerPerformerRegex = new Regex(@"By\s.*?\s\u2014");
             var songComposerPerformer = composerPerformerRegex.Matches(songAlbumArtist);
             try {
@@ -193,7 +193,7 @@ namespace AMWin_RichPresence {
             //  Get song timestamps
             // ------------------------------------------------
 
-            var currentTimeElement       = amWinLCD.FindFirst(TreeScope.Children, new PropertyCondition(AutomationElement.AutomationIdProperty, "CurrentTime"));
+            var currentTimeElement = amWinLCD.FindFirst(TreeScope.Children, new PropertyCondition(AutomationElement.AutomationIdProperty, "CurrentTime"));
             var remainingDurationElement = amWinLCD.FindFirst(TreeScope.Children, new PropertyCondition(AutomationElement.AutomationIdProperty, "Duration"));
 
             // grab the seek slider to check song playback progress

--- a/AMWin-RichPresence/AppleMusicScrobbler.cs
+++ b/AMWin-RichPresence/AppleMusicScrobbler.cs
@@ -1,6 +1,7 @@
 ﻿using IF.Lastfm.Core.Api;
 using IF.Lastfm.Core.Objects;
 using IF.Lastfm.Core.Scrobblers;
+using MetaBrainz.ListenBrainz;
 using System;
 using System.Diagnostics;
 using System.Linq;
@@ -9,39 +10,125 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Windows;
 
-namespace AMWin_RichPresence
-{
-    public struct LastFmCredentials {
+namespace AMWin_RichPresence {
+    internal interface IScrobblerCredentials { }
+
+    public struct LastFmCredentials : IScrobblerCredentials {
         public string apiKey;
         public string apiSecret;
         public string username;
         public string password;
     }
-    internal class AppleMusicScrobbler
-    {
 
-        private LastAuth? lastfmAuth;
-        private IScrobbler? lastFmScrobbler;
-        private ITrackApi? trackApi;
-        private HttpClient? httpClient;
-        private int elapsedSeconds;
-        private string? lastSongID;
-        private bool hasScrobbled;
-        private double lastSongProgress;
-        private Logger? logger;
+    public struct ListenBrainzCredentials : IScrobblerCredentials {
+        public string userToken;
+    }
 
-        public AppleMusicScrobbler(Logger? logger = null) { 
-            this.logger = logger; 
-        }           
-        
+    internal class AlbumCleaner {
+
         public static string CleanAlbumName(string songName) {
             // Remove " - Single" and " - EP"
             var re = new Regex(@"\s-\s((Single)|(EP))$");
             return re.Replace(songName, new MatchEvaluator((m) => { return ""; }));
         }
 
-        public async Task<bool> init(LastFmCredentials credentials)
-        {
+    }
+
+    internal abstract class AppleMusicScrobbler<C> where C : IScrobblerCredentials {
+        protected int elapsedSeconds;
+        protected string? lastSongID;
+        protected bool hasScrobbled;
+        protected double lastSongProgress;
+        protected Logger? logger;
+        protected string serviceName;
+
+        public AppleMusicScrobbler(string serviceName, Logger? logger = null) {
+            this.serviceName = serviceName;
+            this.logger = logger;
+        }
+
+        protected bool IsTimeToScrobble(AppleMusicInfo info) {
+            if (info.SongDuration.HasValue && info.SongDuration.Value >= 30) { // we should only scrobble tracks with more than 30 seconds
+                double halfSongDuration = info.SongDuration.Value / 2;
+                return elapsedSeconds >= halfSongDuration || elapsedSeconds >= 240; // half the song has passed or more than 4 minutes
+            }
+            return elapsedSeconds > Constants.LastFMTimeBeforeScrobbling;
+        }
+
+        protected bool IsRepeating(AppleMusicInfo info) {
+            if (info.CurrentTime.HasValue && info.SongDuration.HasValue) {
+                double currentTime = info.CurrentTime.Value;
+                double songDuration = info.SongDuration.Value;
+                double repeatThreshold = 1.5 * Constants.RefreshPeriod;
+                return currentTime <= repeatThreshold && lastSongProgress >= (songDuration - repeatThreshold);
+            }
+
+            return false;
+        }
+
+        public abstract Task<bool> init(C credentials);
+
+        public abstract Task<bool> UpdateCredsAsync(C credentials);
+
+        protected abstract Task UpdateNowPlaying(string artist, string album, string song);
+
+        protected abstract Task ScrobbleSong(string artist, string album, string song);
+
+        public async void Scrobbleit(AppleMusicInfo info) {
+            // This gets called every five seconds (Constants.RefreshPeriod) when a song is playing. There are some rules before we want to scrobble.
+            // First, when the song changes, start start "our" timer over at 0.  Every time this gets called, increment by five seconds (RefreshPeriod).
+            // If we hit the threshold (Constants.LastFMTimeBeforeScrobbling) then go ahead and Scrobble it.  Note that this works well because this method
+            //    never gets called when the song is paused!  Also, make sure that we don't keep re-Scrobbling, so set a variable "hasScrobbled" for each song.
+            //
+            // Important caveat:  this does not have any "Scrobbler queue" built in - so only real-time Scrobbling will work (no offline capability).  Fair trade-off
+            //    until an official Scrobbler is released.
+
+            try {
+                var thisSongID = info.SongArtist + info.SongName + info.SongAlbum;
+                var webScraper = new AppleMusicWebScraper(info.SongName, info.SongAlbum, info.SongArtist);
+                var artist = Properties.Settings.Default.LastfmScrobblePrimaryArtist ? webScraper.GetArtistList().FirstOrDefault(info.SongArtist) : info.SongArtist;
+                var album = Properties.Settings.Default.LastfmCleanAlbumName ? AlbumCleaner.CleanAlbumName(info.SongAlbum) : info.SongAlbum;
+
+                if (thisSongID != lastSongID) {
+                    lastSongID = thisSongID;
+                    elapsedSeconds = 0;
+                    hasScrobbled = false;
+                    logger?.Log($"[{serviceName} scrobbler] New Song: {lastSongID}");
+
+                    await UpdateNowPlaying(artist, album, info.SongName);
+                    logger?.Log($"[{serviceName} scrobbler] Updated now playing: {lastSongID}");
+                } else {
+                    elapsedSeconds += Constants.RefreshPeriod;
+
+                    if (hasScrobbled && IsRepeating(info)) {
+                        hasScrobbled = false;
+                        elapsedSeconds = 0;
+                        logger?.Log($"[{serviceName} scrobbler] Repeating Song: {lastSongID}");
+                    }
+
+                    if (IsTimeToScrobble(info) && !hasScrobbled) {
+                        logger?.Log($"[{serviceName} scrobbler] Scrobbling: {lastSongID}");
+                        await ScrobbleSong(artist, album, info.SongName);
+                        hasScrobbled = true;
+                    }
+
+                    lastSongProgress = info.CurrentTime ?? 0.0;
+                }
+            } catch (Exception ex) {
+                logger?.Log($"[{serviceName} scrobbler] An error occurred while scrobbling: {ex}");
+            }
+        }
+    }
+
+    internal class AppleMusicLastFmScrobbler : AppleMusicScrobbler<LastFmCredentials> {
+        private LastAuth? lastfmAuth;
+        private IScrobbler? lastFmScrobbler;
+        private ITrackApi? trackApi;
+        private HttpClient? httpClient;
+
+        public AppleMusicLastFmScrobbler(Logger? logger = null) : base("Last.FM", logger) { }
+
+        public async override Task<bool> init(LastFmCredentials credentials) {
             if (string.IsNullOrEmpty(credentials.apiKey)
                 || string.IsNullOrEmpty(credentials.apiSecret)
                 || string.IsNullOrEmpty(credentials.username)) {
@@ -64,17 +151,7 @@ namespace AMWin_RichPresence
             return lastfmAuth.Authenticated;
         }
 
-        public IScrobbler? GetLastFmScrobbler()
-        {
-            return lastFmScrobbler;
-        }
-
-        public ITrackApi? GetTrackApi()
-        {
-            return trackApi;
-        }
-
-        public async Task<bool> UpdateCredsAsync(LastFmCredentials credentials) {
+        public async override Task<bool> UpdateCredsAsync(LastFmCredentials credentials) {
             logger?.Log("[Last.FM scrobbler] Updating credentials");
             httpClient = null;
             lastfmAuth = null;
@@ -83,85 +160,69 @@ namespace AMWin_RichPresence
             return await init(credentials);
         }
 
-        public async void Scrobbleit(AppleMusicInfo info, IScrobbler lastFmScrobbler, ITrackApi trackApi)
-        {
-            // This gets called every five seconds (Constants.RefreshPeriod) when a song is playing. There are some rules before we want to scrobble.
-            // First, when the song changes, start start "our" timer over at 0.  Every time this gets called, increment by five seconds (RefreshPeriod).
-            // If we hit the threshold (Constants.LastFMTimeBeforeScrobbling) then go ahead and Scrobble it.  Note that this works well because this method
-            //    never gets called when the song is paused!  Also, make sure that we don't keep re-Scrobbling, so set a variable "hasScrobbled" for each song.
-            //
-            // Important caveat:  this does not have any "Scrobbler queue" built in - so only real-time Scrobbling will work (no offline capability).  Fair trade-off
-            //    until an official Scrobbler is released.
-
-            try
-            {
-                var thisSongID = info.SongArtist + info.SongName + info.SongAlbum;
-                var webScraper = new AppleMusicWebScraper(info.SongName, info.SongAlbum, info.SongArtist);
-                var scrobble = new Scrobble(
-                    Properties.Settings.Default.LastfmScrobblePrimaryArtist ? webScraper.GetArtistList().FirstOrDefault(info.SongArtist) : info.SongArtist,
-                    Properties.Settings.Default.LastfmCleanAlbumName ? CleanAlbumName(info.SongAlbum) : info.SongAlbum,
-                    info.SongName,
-                    DateTime.UtcNow);
-
-                if (thisSongID != lastSongID)
-                {
-                    lastSongID = thisSongID;
-                    elapsedSeconds = 0;
-                    hasScrobbled = false;
-                    logger?.Log($"[Last.FM scrobbler] New Song: {lastSongID}");
-
-                    await trackApi.UpdateNowPlayingAsync(scrobble);
-                    logger?.Log($"[Last.FM scrobbler] Updated now playing: {lastSongID}");
-                }
-                else
-                {
-                    elapsedSeconds += Constants.RefreshPeriod;
-
-                    if (hasScrobbled && IsRepeating(info))
-                    {
-                        hasScrobbled = false;
-                        elapsedSeconds = 0;
-                        logger?.Log($"[Last.FM scrobbler] Repeating Song: {lastSongID}");
-                    }
-
-                    if (IsTimeToScrobble(info) && !hasScrobbled)
-                    {
-                        if (lastfmAuth != null && lastfmAuth.Authenticated)
-                        {
-                            logger?.Log($"[Last.FM scrobbler] Scrobbling: {lastSongID}");
-                            
-                            var response = await lastFmScrobbler.ScrobbleAsync(scrobble);
-                        }
-                        hasScrobbled = true;
-                    }
-
-                    lastSongProgress = info.CurrentTime ?? 0.0;
-                }
+        protected async override Task ScrobbleSong(string artist, string album, string song) {
+            if (lastFmScrobbler == null || lastfmAuth?.Authenticated != true) {
+                return;
             }
-            catch (Exception ex)
-            {
-                logger?.Log($"[Last.FM scrobbler] An error occurred while scrobbling: {ex}");
-            }
+
+            var scrobble = new Scrobble(artist, album, song, DateTime.UtcNow);
+            await lastFmScrobbler.ScrobbleAsync(scrobble);
         }
 
-        private bool IsTimeToScrobble(AppleMusicInfo info)
-        {
-            if (info.SongDuration.HasValue && info.SongDuration.Value >= 30 ) { // we should only scrobble tracks with more than 30 seconds
-                double halfSongDuration = info.SongDuration.Value / 2;
-                return elapsedSeconds >= halfSongDuration || elapsedSeconds >= 240; // half the song has passed or more than 4 minutes
-            }
-            return elapsedSeconds > Constants.LastFMTimeBeforeScrobbling;
-        }
-        private bool IsRepeating(AppleMusicInfo info) {
-            if (info.CurrentTime.HasValue && info.SongDuration.HasValue)
-            {
-                double currentTime = info.CurrentTime.Value;
-                double songDuration = info.SongDuration.Value;
-                double repeatThreshold =  1.5 * Constants.RefreshPeriod;
-                return currentTime <= repeatThreshold && lastSongProgress >= (songDuration - repeatThreshold);
+        protected async override Task UpdateNowPlaying(string artist, string album, string song) {
+            if (trackApi == null || !lastfmAuth?.Authenticated != true) {
+                return;
             }
 
-            return false;
+            var scrobble = new Scrobble(artist, album, song, DateTime.UtcNow);
+            await trackApi.UpdateNowPlayingAsync(scrobble);
+        }
+    }
+
+    internal class AppleMusicListenBrainzScrobbler : AppleMusicScrobbler<ListenBrainzCredentials> {
+        private ListenBrainz? listenBrainzClient;
+
+        public AppleMusicListenBrainzScrobbler(Logger? logger = null) : base("ListenBrainz", logger) { }
+
+        public async override Task<bool> init(ListenBrainzCredentials credentials) {
+            if (string.IsNullOrEmpty(credentials.userToken)) {
+                logger?.Log("No ListenBrainz user token found");
+                return false;
+            }
+
+            listenBrainzClient = new();
+            var tokenValidation = await listenBrainzClient.ValidateTokenAsync(credentials.userToken);
+
+            if (tokenValidation.Valid == true) {
+                logger?.Log("ListenBrainz authentication succeeded");
+                listenBrainzClient.UserToken = credentials.userToken;
+            } else {
+                logger?.Log("ListenBrainz authentication failed");
+                listenBrainzClient.UserToken = null;
+            }
+
+            return tokenValidation.Valid ?? false;
+        }
+
+        public async override Task<bool> UpdateCredsAsync(ListenBrainzCredentials credentials) {
+            logger?.Log("[ListenBrainz] Updating credentials");
+            return await init(credentials);
+        }
+
+        protected async override Task ScrobbleSong(string artist, string album, string song) {
+            if (string.IsNullOrEmpty(listenBrainzClient?.UserToken)) {
+                return;
+            }
+
+            await listenBrainzClient.SubmitSingleListenAsync(song, artist, album);
+        }
+
+        protected async override Task UpdateNowPlaying(string artist, string album, string song) {
+            if (string.IsNullOrEmpty(listenBrainzClient?.UserToken)) {
+                return;
+            }
+
+            await listenBrainzClient.SetNowPlayingAsync(song, artist, album);
         }
     }
 }

--- a/AMWin-RichPresence/AppleMusicScrobbler.cs
+++ b/AMWin-RichPresence/AppleMusicScrobbler.cs
@@ -170,7 +170,7 @@ namespace AMWin_RichPresence {
         }
 
         protected async override Task UpdateNowPlaying(string artist, string album, string song) {
-            if (trackApi == null || !lastfmAuth?.Authenticated != true) {
+            if (trackApi == null || lastfmAuth?.Authenticated != true) {
                 return;
             }
 

--- a/AMWin-RichPresence/AppleMusicScrobbler.cs
+++ b/AMWin-RichPresence/AppleMusicScrobbler.cs
@@ -185,12 +185,13 @@ namespace AMWin_RichPresence {
         public AppleMusicListenBrainzScrobbler(Logger? logger = null) : base("ListenBrainz", logger) { }
 
         public async override Task<bool> init(ListenBrainzCredentials credentials) {
+            listenBrainzClient = new();
+
             if (string.IsNullOrEmpty(credentials.userToken)) {
                 logger?.Log("No ListenBrainz user token found");
                 return false;
             }
 
-            listenBrainzClient = new();
             var tokenValidation = await listenBrainzClient.ValidateTokenAsync(credentials.userToken);
 
             if (tokenValidation.Valid == true) {

--- a/AMWin-RichPresence/AppleMusicWebScraper.cs
+++ b/AMWin-RichPresence/AppleMusicWebScraper.cs
@@ -101,7 +101,7 @@ namespace AMWin_RichPresence {
                 }
                 return null;
             } catch (Exception ex) {
-                logger?.Log($"[SearchTopResults] An exception occurred: {ex}"); 
+                logger?.Log($"[SearchTopResults] An exception occurred: {ex}");
                 return null;
             }
         }
@@ -187,7 +187,7 @@ namespace AMWin_RichPresence {
                 }
                 return new();
             } catch (Exception ex) {
-                logger?.Log($"[GetArtistList] An exception occurred: {ex}"); 
+                logger?.Log($"[GetArtistList] An exception occurred: {ex}");
                 return new();
             }
         }
@@ -202,13 +202,13 @@ namespace AMWin_RichPresence {
                     logger?.Log($"[GetAlbumArtUrl] LastFM lookup failed, falling back to Apple Music Web");
                 }
                 return lastFmImg ?? await GetAlbumArtUrlAppleMusic();
-            } catch (Exception ex) { 
-                logger?.Log($"[GetAlbumArtUrl] An exception occurred: {ex}"); 
-                return null; 
+            } catch (Exception ex) {
+                logger?.Log($"[GetAlbumArtUrl] An exception occurred: {ex}");
+                return null;
             }
         }
         private async Task<string?> GetAlbumArtUrlLastFm() {
-            var url = $"http://ws.audioscrobbler.com/2.0/?method=album.getinfo&api_key={lastFmApiKey}&artist={Uri.EscapeDataString(songArtist)}&album={Uri.EscapeDataString(AppleMusicScrobbler.CleanAlbumName(songAlbum))}&format=json";
+            var url = $"http://ws.audioscrobbler.com/2.0/?method=album.getinfo&api_key={lastFmApiKey}&artist={Uri.EscapeDataString(songArtist)}&album={Uri.EscapeDataString(AlbumCleaner.CleanAlbumName(songAlbum))}&format=json";
             var j = await GetURLJson(url, "GetAlbumArtUrlLastFm");
             var imgs = j.RootElement.GetProperty("album").GetProperty("image");
             foreach (var img in imgs.EnumerateArray()) {
@@ -221,7 +221,7 @@ namespace AMWin_RichPresence {
         }
         private async Task<string?> GetAlbumArtUrlAppleMusic() {
             try {
-                // try searching in "Songs" section 
+                // try searching in "Songs" section
                 var result = SearchSongs();
                 if (result != null) {
                     return GetLargestImageUrl(result);
@@ -236,7 +236,7 @@ namespace AMWin_RichPresence {
                 // TODO: search in "Albums" section?
                 return null;
             } catch (Exception ex) {
-                logger?.Log($"[GetAlbumArtUrlAppleMusic] An exception occurred: {ex}"); 
+                logger?.Log($"[GetAlbumArtUrlAppleMusic] An exception occurred: {ex}");
                 return null;
             }
         }
@@ -291,7 +291,7 @@ namespace AMWin_RichPresence {
                         .Value;
 
                     return await GetSongDurationFromAlbumPage(searchResultUrl);
-                }    
+                }
                 return null;
             } catch (Exception ex) {
                 logger?.Log($"[GetSongDurationAppleMusic] An exception occurred: {ex}");
@@ -308,7 +308,7 @@ namespace AMWin_RichPresence {
                 var str = desc.Attributes["content"].Value;
                 var songTitle = new Regex(@"(?<=Listen to ).*(?= by)").Matches(str).First().Value;
                 var duration = new Regex(@"(?<=Duration: )\S*$").Matches(str).First().Value;
-                
+
                 // check that the result actually is the song
                 if (HttpUtility.HtmlDecode(songTitle) == songName) {
                     return duration;

--- a/AMWin-RichPresence/Properties/Settings.Designer.cs
+++ b/AMWin-RichPresence/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace AMWin_RichPresence.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.5.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.8.0.0")]
     public sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -85,6 +85,18 @@ namespace AMWin_RichPresence.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string ListenBrainzUserToken {
+            get {
+                return ((string)(this["ListenBrainzUserToken"]));
+            }
+            set {
+                this["ListenBrainzUserToken"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("True")]
         public bool ShowAppleMusicIcon {
             get {
@@ -140,6 +152,18 @@ namespace AMWin_RichPresence.Properties {
             }
             set {
                 this["LastfmEnable"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool ListenBrainzEnable {
+            get {
+                return ((bool)(this["ListenBrainzEnable"]));
+            }
+            set {
+                this["ListenBrainzEnable"] = value;
             }
         }
         

--- a/AMWin-RichPresence/Properties/Settings.settings
+++ b/AMWin-RichPresence/Properties/Settings.settings
@@ -17,6 +17,9 @@
     <Setting Name="LastfmUsername" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
+    <Setting Name="ListenBrainzUserToken" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
     <Setting Name="ShowAppleMusicIcon" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
@@ -30,6 +33,9 @@
       <Value Profile="(Default)">False</Value>
     </Setting>
     <Setting Name="LastfmEnable" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
+    <Setting Name="ListenBrainzEnable" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
     <Setting Name="ShowRPWhenMusicPaused" Type="System.Boolean" Scope="User">

--- a/AMWin-RichPresence/SettingsWindow.xaml
+++ b/AMWin-RichPresence/SettingsWindow.xaml
@@ -7,7 +7,7 @@
         xmlns:properties="clr-namespace:AMWin_RichPresence.Properties"
         mc:Ignorable="d"
         Icon="/Resources/AMWinRP.ico"
-        Title="AMWin-RichPresence" Height="560" Width="440" ResizeMode="NoResize" WindowStartupLocation="CenterScreen">
+        Title="AMWin-RichPresence" ResizeMode="NoResize" WindowStartupLocation="CenterScreen" Width="470" Height="645">
     <Grid Background="{DynamicResource {x:Static SystemColors.ControlBrushKey}}">
         <DockPanel>
             <Border DockPanel.Dock="Top" Height="64" Padding="10" Background="{DynamicResource {x:Static SystemColors.ControlLightBrushKey}}" BorderBrush="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}" BorderThickness="0 0 0 1.5">
@@ -24,7 +24,7 @@
                     <Grid>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="160"/>
-                            <ColumnDefinition Width="120"/>
+                            <ColumnDefinition Width="260"/>
                         </Grid.ColumnDefinitions>
                         <Grid.RowDefinitions>
                             <RowDefinition Height="25"/>
@@ -42,23 +42,23 @@
 
                         <TextBlock Grid.Row="1" Grid.Column="0">Treat composer as artist</TextBlock>
                         <CheckBox Grid.Row="1" Grid.Column="1" x:Name="CheckBox_ClassicalComposerAsArtist" Margin="0 2 0 0" IsChecked="{Binding Source={x:Static properties:Settings.Default}, Path=ClassicalComposerAsArtist, Mode=TwoWay}" Click="CheckBox_ClassicalComposerAsArtist_Click"/>
-  
-                        <TextBlock Grid.Row="2" VerticalAlignment="Top" FontWeight="Bold" Padding="0 3 0 0">Discord settings</TextBlock>
+
+                        <TextBlock Grid.Row="2" FontWeight="Bold" Padding="0 3 0 0" VerticalAlignment="Top">Discord settings</TextBlock>
 
                         <TextBlock Grid.Row="3" Grid.Column="0"  Padding="10 0 0 0">Enable Discord RP</TextBlock>
-                        <CheckBox Grid.Row="3" Grid.Column="1" x:Name="CheckBox_EnableDiscordRP" Margin="0,2,0,0" IsChecked="{Binding Source={x:Static properties:Settings.Default}, Path=EnableDiscordRP, Mode=TwoWay}" Click="CheckBox_EnableDiscordRP_Click" HorizontalAlignment="Right" Width="120"/>
+                        <CheckBox Grid.Row="3" Grid.Column="1" x:Name="CheckBox_EnableDiscordRP" Margin="0,2,0,0" IsChecked="{Binding Source={x:Static properties:Settings.Default}, Path=EnableDiscordRP, Mode=TwoWay}" Click="CheckBox_EnableDiscordRP_Click"/>
 
                         <TextBlock Grid.Row="4" Grid.Column="0"  Padding="10 0 0 0">Enable cover images</TextBlock>
-                        <CheckBox Grid.Row="4" Grid.Column="1" x:Name="CheckBox_EnableRPCoverImages" Margin="0 2 0 0" IsChecked="{Binding Source={x:Static properties:Settings.Default}, Path=EnableRPCoverImages, Mode=TwoWay}" Click="CheckBox_EnableRPCoverImages_Click"></CheckBox>
+                        <CheckBox Grid.Row="4" Grid.Column="1" x:Name="CheckBox_EnableRPCoverImages" Margin="0 2 0 0" IsChecked="{Binding Source={x:Static properties:Settings.Default}, Path=EnableRPCoverImages, Mode=TwoWay}" Click="CheckBox_EnableRPCoverImages_Click"/>
 
                         <TextBlock Grid.Row="5" Grid.Column="0"  Padding="10 0 0 0">RP when music paused</TextBlock>
-                        <CheckBox Grid.Row="5" Grid.Column="1" x:Name="CheckBox_ShowRPWhenMusicPaused" Margin="0 2 0 0" IsChecked="{Binding Source={x:Static properties:Settings.Default}, Path=ShowRPWhenMusicPaused, Mode=TwoWay}" Click="CheckBox_ShowRPWhenMusicPaused_Click"></CheckBox>
+                        <CheckBox Grid.Row="5" Grid.Column="1" x:Name="CheckBox_ShowRPWhenMusicPaused" Margin="0 2 0 0" IsChecked="{Binding Source={x:Static properties:Settings.Default}, Path=ShowRPWhenMusicPaused, Mode=TwoWay}" Click="CheckBox_ShowRPWhenMusicPaused_Click"/>
 
                         <TextBlock Grid.Row="6" Grid.Column="0"  Padding="10 0 0 0">Apple Music icon in status</TextBlock>
                         <CheckBox Grid.Row="6" Grid.Column="1" x:Name="CheckBox_ShowAppleMusicIcon" Margin="0 2 0 0" IsChecked="{Binding Source={x:Static properties:Settings.Default}, Path=ShowAppleMusicIcon, Mode=TwoWay}" Click="CheckBox_ShowAppleMusicIcon_Click"></CheckBox>
 
-                        <TextBlock Grid.Row="7" Grid.Column="0" VerticalAlignment="Center" Margin="0 0 0 2"  Padding="10 0 0 0">Rich Presence subtitle</TextBlock>
-                        <ComboBox Grid.Row="7" Grid.Column="1" x:Name="ComboBox_RPSubtitleChoice" SelectedIndex="{Binding Source={x:Static properties:Settings.Default}, Path=RPSubtitleChoice, Mode=TwoWay}" Height="22" SelectionChanged="ComboBox_RPSubtitleChoice_SelectionChanged">
+                        <TextBlock Grid.Row="7" Grid.Column="0" Margin="0 0 0 2"  Padding="10 0 0 0" VerticalAlignment="Center">Rich Presence subtitle</TextBlock>
+                        <ComboBox Grid.Row="7" Grid.Column="1" x:Name="ComboBox_RPSubtitleChoice" SelectedIndex="{Binding Source={x:Static properties:Settings.Default}, Path=RPSubtitleChoice, Mode=TwoWay}" Height="22" SelectionChanged="ComboBox_RPSubtitleChoice_SelectionChanged" Margin="0,1,145,2">
                             <!-- The order of these items matters! (check the enum in AppleMusicDiscordClient.cs) -->
                             <ComboBoxItem>Artist and album</ComboBoxItem>
                             <ComboBoxItem>Artist only</ComboBoxItem>
@@ -69,44 +69,53 @@
                     <Grid>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="160"/>
-                            <ColumnDefinition Width="110"/>
+                            <ColumnDefinition Width="260"/>
                         </Grid.ColumnDefinitions>
                         <Grid.RowDefinitions>
                             <RowDefinition Height="25"/>
                             <RowDefinition Height="25"/>
                             <RowDefinition Height="25"/>
+                            <RowDefinition Height="15"/>
                             <RowDefinition Height="25"/>
                             <RowDefinition Height="25"/>
                             <RowDefinition Height="25"/>
+                            <RowDefinition Height="25"/>
+                            <RowDefinition Height="25"/>
+                            <RowDefinition Height="15"/>
                             <RowDefinition Height="25"/>
                             <RowDefinition Height="25"/>
                             <RowDefinition Height="25"/>
                         </Grid.RowDefinitions>
-                        <TextBlock Grid.Row="0" VerticalAlignment="Top" FontWeight="Bold" Padding="0 3 0 0">Last.FM settings</TextBlock>
+                        <TextBlock Grid.Row="0" VerticalAlignment="Top" FontWeight="Bold" Padding="0 3 0 0">Scrobbling settings</TextBlock>
 
-                        <TextBlock Grid.Row="1" Grid.Column="0"  Padding="10 0 0 0">Enable Last.FM scrobbling</TextBlock>
-                        <CheckBox Grid.Row="1" Grid.Column="1" x:Name="CheckBox_LastfmEnable" Margin="0,2,0,0" IsChecked="{Binding Source={x:Static properties:Settings.Default}, Path=LastfmEnable, Mode=TwoWay}"  Click="CheckBox_LastfmEnable_Click"/>
+                        <TextBlock Grid.Row="1" Grid.Column="0"  Padding="10 0 0 0">Clean album name</TextBlock>
+                        <CheckBox Grid.Row="1" Grid.Column="1" x:Name="CheckBox_LastfmCleanAlbumName" Margin="0,2,0,0" IsChecked="{Binding Source={x:Static properties:Settings.Default}, Path=LastfmCleanAlbumName, Mode=TwoWay}"  Click="CheckBox_LastfmCleanAlbumName_Click"/>
 
-                        <TextBlock Grid.Row="2" Grid.Column="0"  Padding="10 0 0 0">Clean album name</TextBlock>
-                        <CheckBox Grid.Row="2" Grid.Column="1" x:Name="CheckBox_LastfmCleanAlbumName" Margin="0,2,0,0" IsChecked="{Binding Source={x:Static properties:Settings.Default}, Path=LastfmCleanAlbumName, Mode=TwoWay}"  Click="CheckBox_LastfmCleanAlbumName_Click"/>
+                        <TextBlock Grid.Row="2" Grid.Column="0" Padding="10 0 0 0">Scrobble primary artist</TextBlock>
+                        <CheckBox Grid.Row="2" Grid.Column="1" x:Name="CheckBox_LastfmScrobblePrimary" Margin="0,2,0,0" IsChecked="{Binding Source={x:Static properties:Settings.Default}, Path=LastfmScrobblePrimaryArtist, Mode=TwoWay}" Click="CheckBox_LastfmScrobblePrimary_Click"/>
 
-                        <TextBlock Grid.Row="3" Grid.Column="0" Padding="10 0 0 0">Scrobble primary artist</TextBlock>
-                        <CheckBox Grid.Row="3" Grid.Column="1" x:Name="CheckBox_LastfmScrobblePrimary" Margin="0,2,0,0" IsChecked="{Binding Source={x:Static properties:Settings.Default}, Path=LastfmScrobblePrimaryArtist, Mode=TwoWay}" Click="CheckBox_LastfmScrobblePrimary_Click"/>
+                        <TextBlock Grid.Row="4" Grid.Column="0"  Padding="10 0 0 0" VerticalAlignment="Center">Enable Last.FM scrobbling</TextBlock>
+                        <CheckBox Grid.Row="4" Grid.Column="1" x:Name="CheckBox_LastfmEnable" Margin="0,2,0,0" IsChecked="{Binding Source={x:Static properties:Settings.Default}, Path=LastfmEnable, Mode=TwoWay}"  Click="CheckBox_LastfmEnable_Click" VerticalAlignment="Center"/>
 
-                        <TextBlock Grid.Row="4" Grid.Column="0" VerticalAlignment="Center" Padding="10 0 0 0">API Key</TextBlock>
-                        <TextBox Grid.Row="4" Grid.Column="1" x:Name="LastfmAPIKey" Text="{Binding Source={x:Static properties:Settings.Default}, Path=Default.LastfmAPIKey}" TextWrapping="Wrap" Margin="0,0,-121,0" FontFamily="Cascadia Code" VerticalAlignment="Center"/>
+                        <TextBlock Grid.Row="5" Grid.Column="0" Padding="10 0 0 0" VerticalAlignment="Center">[Last.fm] API Key</TextBlock>
+                        <TextBox Grid.Row="5" Grid.Column="1" x:Name="LastfmAPIKey" Text="{Binding Source={x:Static properties:Settings.Default}, Path=Default.LastfmAPIKey}" TextWrapping="Wrap" FontFamily="Cascadia Code" Width="260" VerticalAlignment="Center"/>
 
-                        <TextBlock Grid.Row="5" Grid.Column="0" VerticalAlignment="Center" Padding="10 0 0 0">API Secret</TextBlock>
-                        <TextBox Grid.Row="5" Grid.Column="1" x:Name="LastfmSecret" Text="{Binding Source={x:Static properties:Settings.Default}, Path=Default.LastfmSecret}" TextWrapping="Wrap" Margin="0,0,-121,0" FontFamily="Cascadia Code" VerticalAlignment="Center"/>
+                        <TextBlock Grid.Row="6" Grid.Column="0" VerticalAlignment="Center" Padding="10 0 0 0">[Last.fm] API Secret</TextBlock>
+                        <TextBox Grid.Row="6" Grid.Column="1" x:Name="LastfmSecret" Text="{Binding Source={x:Static properties:Settings.Default}, Path=Default.LastfmSecret}" TextWrapping="Wrap" FontFamily="Cascadia Code" VerticalAlignment="Center" Width="260"/>
 
-                        <TextBlock Grid.Row="6" Grid.Column="0" VerticalAlignment="Center" Padding="10 0 0 0">Username</TextBlock>
-                        <TextBox Grid.Row="6" Grid.Column="1" x:Name="LastfmUsername" Text="{Binding Source={x:Static properties:Settings.Default}, Path=Default.LastfmUsername}" TextWrapping="Wrap" Margin="0,0,-121,0" VerticalAlignment="Center"/>
+                        <TextBlock Grid.Row="7" Grid.Column="0" VerticalAlignment="Center" Padding="10 0 0 0">[Last.fm] Username</TextBlock>
+                        <TextBox Grid.Row="7" Grid.Column="1" x:Name="LastfmUsername" Text="{Binding Source={x:Static properties:Settings.Default}, Path=Default.LastfmUsername}" TextWrapping="Wrap" VerticalAlignment="Center" Width="260"/>
 
-                        <TextBlock Grid.Row="7" Grid.Column="0" VerticalAlignment="Center" Padding="10 0 0 0">Password</TextBlock>
-                        <PasswordBox Grid.Row="7" Grid.Column="1" x:Name="LastfmPassword" VerticalAlignment="Center" Margin="0,0,-121,0"/>
+                        <TextBlock Grid.Row="8" Grid.Column="0" VerticalAlignment="Center" Padding="10 0 0 0">[Last.fm] Password</TextBlock>
+                        <PasswordBox Grid.Row="8" Grid.Column="1" x:Name="LastfmPassword" VerticalAlignment="Center"/>
 
-                        <Button Grid.Row="8" Grid.Column="1" Content="Button" HorizontalAlignment="Left" Margin="201,10,0,0" VerticalAlignment="Top" Width="0"/>
-                        <Button Grid.Row="8" Grid.Column="1" x:Name="SaveLastFMCreds" Content="Save Credentials" VerticalAlignment="Center" Margin="129,5,-121,0" Click="SaveLastFMCreds_Click"/>
+                        <TextBlock Grid.Row="10" Grid.Column="0"  Padding="10 0 0 0" VerticalAlignment="Center">Enable ListenBrainz</TextBlock>
+                        <CheckBox Grid.Row="10" Grid.Column="1" x:Name="CheckBox_ListenBrainzEnable" Margin="0,2,0,0" IsChecked="{Binding Source={x:Static properties:Settings.Default}, Path=ListenBrainzEnable, Mode=TwoWay}"  Click="CheckBox_ListenBrainzEnable_Click" VerticalAlignment="Center"/>
+
+                        <TextBlock Grid.Row="11" Grid.Column="0" VerticalAlignment="Center" Padding="10 0 0 0">[ListenBrainz] User token</TextBlock>
+                        <TextBox Grid.Row="11" Grid.Column="1" x:Name="ListenBrainzUserToken" Text="{Binding Source={x:Static properties:Settings.Default}, Path=Default.ListenBrainzUserToken, Mode=TwoWay}" TextWrapping="Wrap" FontFamily="Cascadia Code" VerticalAlignment="Center"/>
+
+                        <Button Grid.Row="12" Grid.Column="1" x:Name="SaveLastFMCreds" Content="Save Credentials" VerticalAlignment="Center" Click="SaveLastFMCreds_Click" Margin="150,0,0,0"/>
                     </Grid>
                 </StackPanel>
             </Border>

--- a/AMWin-RichPresence/SettingsWindow.xaml.cs
+++ b/AMWin-RichPresence/SettingsWindow.xaml.cs
@@ -29,6 +29,7 @@ namespace AMWin_RichPresence {
 
             SaveSettings();
         }
+
         private void CheckBox_ClassicalComposerAsArtist_Click(object sender, RoutedEventArgs e) {
             ((App)Application.Current).UpdateScraperPreferences(CheckBox_ClassicalComposerAsArtist.IsChecked == true);
             SaveSettings();
@@ -37,6 +38,7 @@ namespace AMWin_RichPresence {
         private void CheckBox_EnableRPCoverImages_Click(object sender, RoutedEventArgs e) {
             SaveSettings();
         }
+
         private void CheckBox_EnableDiscordRP_Click(object sender, RoutedEventArgs e) {
             SaveSettings();
         }
@@ -59,6 +61,11 @@ namespace AMWin_RichPresence {
         private void CheckBox_LastfmEnable_Click(object sender, RoutedEventArgs e) {
             SaveSettings();
         }
+
+        private void CheckBox_ListenBrainzEnable_Click(object sender, RoutedEventArgs e) {
+            SaveSettings();
+        }
+
         private void CheckBox_LastfmCleanAlbumName_Click(object sender, RoutedEventArgs e) {
             SaveSettings();
         }
@@ -93,15 +100,12 @@ namespace AMWin_RichPresence {
             Properties.Settings.Default.Save();
         }
 
-        private async void SaveLastFMCreds_Click(object sender, RoutedEventArgs e)
-        {
+        private async void SaveLastFMCreds_Click(object sender, RoutedEventArgs e) {
             // Store the actual password to the Credential Manager.  Not as good as true Last.FM tokenized authentication,
             //       but better than storing plain-text password in config file
             //       https://stackoverflow.com/questions/32548714/how-to-store-and-retrieve-credentials-on-windows-using-c-sharp
-            try
-            {
-                using (var cred = new SecureCredential())
-                {
+            try {
+                using (var cred = new SecureCredential()) {
 
                     cred.SecurePassword = ConvertToSecureString(LastfmPassword.Password);
                     cred.Target = Constants.LastFMCredentialTargetName;
@@ -109,27 +113,36 @@ namespace AMWin_RichPresence {
                     cred.PersistanceType = PersistanceType.LocalComputer;
                     cred.Save();
                 }
-            }
-            catch (Exception ex)
-            {
+            } catch (Exception ex) {
                 Trace.WriteLine(ex.Message);
                 Trace.WriteLine(ex.StackTrace);
 
             }
             SaveSettings(); // The other three values are just stored in Settings
 
-            // Signals the LastFM Scrobbler to re-init with new credentials
-            var result = await ((App)Application.Current).UpdateLastfmCreds();
-            if (result) {
-                MessageBox.Show("The Last.FM credentials were successfully authenticated.", "Last.FM Authentication", MessageBoxButton.OK, MessageBoxImage.Information);
-            } else {
-                MessageBox.Show("The Last.FM credentials could not be authenticated. Please make sure you have entered the correct username and password, and that your account is not currently locked.", "Last.FM Authentication", MessageBoxButton.OK, MessageBoxImage.Error);
+            if (Properties.Settings.Default.LastfmEnable) {
+                // Signals the LastFM Scrobbler to re-init with new credentials
+                var result = await ((App)Application.Current).UpdateLastfmCreds();
+                if (result) {
+                    MessageBox.Show("The Last.FM credentials were successfully authenticated.", "Last.FM Authentication", MessageBoxButton.OK, MessageBoxImage.Information);
+                } else {
+                    MessageBox.Show("The Last.FM credentials could not be authenticated. Please make sure you have entered the correct username and password, and that your account is not currently locked.", "Last.FM Authentication", MessageBoxButton.OK, MessageBoxImage.Error);
+                }
+            }
+
+            if (Properties.Settings.Default.ListenBrainzEnable) {
+                // Signals the ListenBrainz Scrobbler to re-init with new credentials
+                var result = await ((App)Application.Current).UpdateListenBrainzCreds();
+                if (result) {
+                    MessageBox.Show("The ListenBrainz credentials were successfully authenticated.", "ListenBrainz Authentication", MessageBoxButton.OK, MessageBoxImage.Information);
+                } else {
+                    MessageBox.Show("The ListenBrainz credentials could not be authenticated. Please make sure you have entered the correct user token.", "ListenBrainz Authentication", MessageBoxButton.OK, MessageBoxImage.Error);
+                }
             }
             // Close();
         }
 
-        private SecureString ConvertToSecureString(string password)
-        {
+        private SecureString ConvertToSecureString(string password) {
             var securePassword = new SecureString();
 
             foreach (char c in password) securePassword.AppendChar(c);
@@ -137,32 +150,24 @@ namespace AMWin_RichPresence {
             return securePassword;
         }
 
-        public static string GetLastFMPassword()
-        {
+        public static string GetLastFMPassword() {
             // Read the stored password from Windows Credential Manager and use it to log into Last.FM
-            try
-            {
-                using (var cred = new SecureCredential())
-                {
+            try {
+                using (var cred = new SecureCredential()) {
                     cred.Target = Constants.LastFMCredentialTargetName;
                     cred.Load();
                     return ToPlainString(cred.SecurePassword);
                 }
-            }
-            catch (Exception ex)
-            {
+            } catch (Exception ex) {
                 Trace.WriteLine(ex.Message);
                 Trace.WriteLine(ex.StackTrace);
                 return String.Empty;
             }
         }
 
-        public static String ToPlainString(System.Security.SecureString secureStr)
-        {
+        public static String ToPlainString(System.Security.SecureString secureStr) {
             String plainStr = new System.Net.NetworkCredential(string.Empty, secureStr).Password;
             return plainStr;
         }
-
-
     }
 }


### PR DESCRIPTION
Implements sending listens to ListenBrainz in addition to scrobbling to Last.fm. I've never worked with C#/.NET before today, so please feel free to tell me if I've done anything completely stupid.

I had some trouble getting things in the WinForm to line up nicely when changing some of the dimensions due to the ListenBrainz token being longer than the existing fields could accommodate and made some changes to the overall widths and margins to get it working, but if there was any magic in the old way it was structured I can go back and try to make fewer overall changes to it.

I'm also not sure regarding the SemVer used, so if you feel that this is a smaller change than what would constitute a minor version bump just let me know.

I'm also currently saving the user token in the plaintext config file, same as the API key from Last.fm, but would be open to storing it in the credential manager instead.