### PR TITLE
Fix HttpClient memory leak and optimize Regex usage

### DIFF
--- a/AMWin-RichPresence/AMWin-RichPresence.csproj
+++ b/AMWin-RichPresence/AMWin-RichPresence.csproj
@@ -10,6 +10,7 @@
     <AssemblyVersion>1.0</AssemblyVersion>
     <FileVersion>1.3.0b1</FileVersion>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
+    <AnalysisLevel>latest-all</AnalysisLevel>
   </PropertyGroup>
 
   <ItemGroup>

--- a/AMWin-RichPresence/AMWin-RichPresence.csproj
+++ b/AMWin-RichPresence/AMWin-RichPresence.csproj
@@ -10,7 +10,6 @@
     <AssemblyVersion>1.0</AssemblyVersion>
     <FileVersion>1.3.0b1</FileVersion>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
-    <AnalysisLevel>latest-all</AnalysisLevel>
   </PropertyGroup>
 
   <ItemGroup>

--- a/AMWin-RichPresence/AppleMusicClientScraper.cs
+++ b/AMWin-RichPresence/AppleMusicClientScraper.cs
@@ -6,9 +6,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using FlaUI.UIA3;
 using FlaUI.Core.Conditions;
-using DiscordRPC.Logging;
 using FlaUI.Core.AutomationElements;
-using System.Xml.Linq;
 
 namespace AMWin_RichPresence {
 
@@ -50,6 +48,7 @@ namespace AMWin_RichPresence {
     }
 
     internal class AppleMusicClientScraper {
+        private static readonly Regex ComposerPerformerRegex = new Regex(@"By\s.*?\s\u2014", RegexOptions.Compiled);
 
         public delegate void RefreshHandler(AppleMusicInfo? newInfo);
         string? lastFmApiKey;
@@ -139,8 +138,7 @@ namespace AMWin_RichPresence {
                 // some classical songs add "By " before the composer's name
                 string? songComposer = null;
                 string? songPerformer = null;
-                var composerPerformerRegex = new Regex(@"By\s.*?\s\u2014");
-                var songComposerPerformer = composerPerformerRegex.Matches(songAlbumArtist);
+                //var songComposerPerformer = ComposerPerformerRegex.Matches(songAlbumArtist);
                 try {
                     var songInfo = ParseSongAlbumArtist(songAlbumArtist, composerAsArtist);
                     songArtist = songInfo.Item1;
@@ -257,8 +255,7 @@ namespace AMWin_RichPresence {
             // some classical songs add "By " before the composer's name
             string? songComposer = null;
             string? songPerformer = null;
-            var composerPerformerRegex = new Regex(@"By\s.*?\s\u2014");
-            var songComposerPerformer = composerPerformerRegex.Matches(songAlbumArtist);
+            var songComposerPerformer = ComposerPerformerRegex.Matches(songAlbumArtist);
             if (songComposerPerformer.Count > 0) {
                 songComposer = songAlbumArtist.Split(" \u2014 ")[0].Remove(0, 3);
                 songPerformer = songAlbumArtist.Split(" \u2014 ")[1];

--- a/AMWin-RichPresence/AppleMusicScrobbler.cs
+++ b/AMWin-RichPresence/AppleMusicScrobbler.cs
@@ -26,10 +26,11 @@ namespace AMWin_RichPresence {
 
     internal class AlbumCleaner {
 
+        private static readonly Regex AlbumCleanerRegex = new Regex(@"\s-\s((Single)|(EP))$", RegexOptions.Compiled);
+
         public static string CleanAlbumName(string songName) {
             // Remove " - Single" and " - EP"
-            var re = new Regex(@"\s-\s((Single)|(EP))$");
-            return re.Replace(songName, new MatchEvaluator((m) => { return ""; }));
+            return AlbumCleanerRegex.Replace(songName, new MatchEvaluator((m) => { return ""; }));
         }
 
     }

--- a/AMWin-RichPresence/AppleMusicScrobbler.cs
+++ b/AMWin-RichPresence/AppleMusicScrobbler.cs
@@ -124,7 +124,6 @@ namespace AMWin_RichPresence {
         private LastAuth? lastfmAuth;
         private IScrobbler? lastFmScrobbler;
         private ITrackApi? trackApi;
-        private HttpClient? httpClient;
 
         public AppleMusicLastFmScrobbler(Logger? logger = null) : base("Last.FM", logger) { }
 
@@ -135,12 +134,11 @@ namespace AMWin_RichPresence {
                 return false;
             }
             // Use the four pieces of information (API Key, API Secret, Username, Password) to log into Last.FM for Scrobbling
-            httpClient = new HttpClient();
             lastfmAuth = new LastAuth(credentials.apiKey, credentials.apiSecret);
             await lastfmAuth.GetSessionTokenAsync(credentials.username, credentials.password);
 
-            lastFmScrobbler = new MemoryScrobbler(lastfmAuth, httpClient);
-            trackApi = new TrackApi(lastfmAuth, httpClient);
+            lastFmScrobbler = new MemoryScrobbler(lastfmAuth, Constants.HttpClient);
+            trackApi = new TrackApi(lastfmAuth, Constants.HttpClient);
 
             if (lastfmAuth.Authenticated) {
                 logger?.Log("Last.FM authentication succeeded");
@@ -153,7 +151,6 @@ namespace AMWin_RichPresence {
 
         public async override Task<bool> UpdateCredsAsync(LastFmCredentials credentials) {
             logger?.Log("[Last.FM scrobbler] Updating credentials");
-            httpClient = null;
             lastfmAuth = null;
             lastFmScrobbler = null;
             trackApi = null;

--- a/AMWin-RichPresence/AppleMusicWebScraper.cs
+++ b/AMWin-RichPresence/AppleMusicWebScraper.cs
@@ -39,12 +39,11 @@ namespace AMWin_RichPresence {
             this.songArtist = songArtist;
         }
         private async Task<HtmlDocument> GetURL(string url, string? callingFunction = null) {
-            var client = new HttpClient();
             // Apple Music web search doesn't like ampersands... even if they're HTML-escaped?
             var cleanUrl = HttpUtility.HtmlEncode(url.Replace("&", " "));
             logger?.Log($"[{callingFunction ?? "GetURL"}] HTTP GET for {cleanUrl}");
             var stopwatch = Stopwatch.StartNew();
-            var res = await client.GetStringAsync(cleanUrl);
+            var res = await Constants.HttpClient.GetStringAsync(cleanUrl);
             stopwatch.Stop();
             logger?.Log($"[{callingFunction ?? "GetURL"}] HTTP GET for {cleanUrl} took {stopwatch.ElapsedMilliseconds}ms");
             HtmlDocument doc = new HtmlDocument();
@@ -52,10 +51,9 @@ namespace AMWin_RichPresence {
             return doc;
         }
         private async Task<JsonDocument> GetURLJson(string url, string? callingFunction = null) {
-            var client = new HttpClient();
             logger?.Log($"[{callingFunction ?? "GetURL"}] HTTP GET for {url}");
             var stopwatch = Stopwatch.StartNew();
-            var res = await client.GetStringAsync(url);
+            var res = await Constants.HttpClient.GetStringAsync(url);
             stopwatch.Stop();
             logger?.Log($"[{callingFunction ?? "GetURL"}] HTTP GET for {url} took {stopwatch.ElapsedMilliseconds}ms");
             return JsonDocument.Parse(res);

--- a/AMWin-RichPresence/AppleMusicWebScraper.cs
+++ b/AMWin-RichPresence/AppleMusicWebScraper.cs
@@ -10,7 +10,11 @@ using System.Diagnostics;
 using System;
 
 namespace AMWin_RichPresence {
-    internal class AppleMusicWebScraper {
+    internal class AppleMusicWebScraper
+    {
+        private static readonly Regex SongTitleRegex = new Regex(@"(?<=Listen to ).*(?= by)", RegexOptions.Compiled);
+        private static readonly Regex DurationRegex = new Regex(@"(?<=Duration: )\S*$", RegexOptions.Compiled);
+        private static readonly Regex ImageUrlRegex = new Regex(@"http\S*?(?= \d{2,3}w)", RegexOptions.Compiled);
         Logger? logger;
         string? lastFmApiKey;
         string songName;
@@ -164,6 +168,7 @@ namespace AMWin_RichPresence {
             try {
                 var result = SearchSongs();
                 if (result != null) {
+                    /*
                     var searchResultUrl = result
                         .Descendants("li")
                         .First(x => x.Attributes["class"].Value.Contains("track-lockup__title"))
@@ -171,6 +176,7 @@ namespace AMWin_RichPresence {
                         .First()
                         .Attributes["href"]
                         .Value;
+                    */
 
                     var searchResultSubtitles = result
                         .Descendants("span")
@@ -246,7 +252,7 @@ namespace AMWin_RichPresence {
 
             var imgUrls = imgSources[0].Attributes["srcset"].Value;
 
-            return new Regex(@"http\S*?(?= \d{2,3}w)").Matches(imgUrls).Last().Value;
+            return ImageUrlRegex.Matches(imgUrls).Last().Value;
         }
 
         // Get song duration
@@ -304,8 +310,8 @@ namespace AMWin_RichPresence {
                     .First(x => x.Attributes.Contains("name") && x.Attributes["name"].Value == "description");
 
                 var str = desc.Attributes["content"].Value;
-                var songTitle = new Regex(@"(?<=Listen to ).*(?= by)").Matches(str).First().Value;
-                var duration = new Regex(@"(?<=Duration: )\S*$").Matches(str).First().Value;
+                var songTitle = SongTitleRegex.Matches(str).First().Value;
+                var duration = DurationRegex.Matches(str).First().Value;
 
                 // check that the result actually is the song
                 if (HttpUtility.HtmlDecode(songTitle) == songName) {

--- a/AMWin-RichPresence/Constants.cs
+++ b/AMWin-RichPresence/Constants.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
+using System.Net.Http;
 
 namespace AMWin_RichPresence {
     internal static class Constants {
@@ -38,6 +39,8 @@ namespace AMWin_RichPresence {
         public static string WindowsAppDataFolder => Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
         public static string AppDataFolder => Path.Combine(WindowsAppDataFolder, AppDataFolderName);
         public static string AppShortcutPath => Path.Join(WindowsStartupFolder, "AMWin-RP.lnk");
-        public static string? ExePath => Process.GetCurrentProcess().MainModule?.FileName;         
+        public static string? ExePath => Process.GetCurrentProcess().MainModule?.FileName;
+
+        public static readonly HttpClient HttpClient = new HttpClient();
     }
 }


### PR DESCRIPTION
* Use shared singleton HttpClient instance to prevent memory leak from creating short-lived HttpClient instances without disposing them. (A singleton HttpClient instance is the recommended use pattern [per Microsoft's documentation](https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/http/httpclient-guidelines#recommended-use).)
* Optimize Regex usage to unnecessary object recreation (`Regex` creation is expensive and should be reused whenever practical).

In my testing, memory usage has been very stable after this fix. Prior to the fix I could observe the memory ticking up and staying there after every HttpClient instance was created. I haven't tested this for an extended period of time but I believe this will mitigate this specific memory leak.