### PR TITLE
fix _SearchTopResults to get title correctly

### DIFF
--- a/AMWin-RichPresence/AppleMusicWebScraper.cs
+++ b/AMWin-RichPresence/AppleMusicWebScraper.cs
@@ -161,6 +161,8 @@ namespace AMWin_RichPresence {
                     var searchResultTitle = result
                         .Descendants("li")
                         .First(x => x.Attributes["data-testid"].Value == "top-search-result-title")
+                        .Descendants("span")
+                        .First()
                         .InnerHtml;
 
                     var searchResultSubtitle = result


### PR DESCRIPTION
In `<li>` with `data-testid=top-search-result-title`, there is `<span>` element needs to be parsed also.

![2024-03-09 04 42 13](https://github.com/PKBeam/AMWin-RP/assets/50207925/1f11e291-be6c-4c24-b7c9-7ef548787ea3)
