### PR TITLE
chore: bump deps

### DIFF
--- a/AMWin-RichPresence/AMWin-RichPresence.csproj
+++ b/AMWin-RichPresence/AMWin-RichPresence.csproj
@@ -21,12 +21,12 @@
   <ItemGroup>
     <PackageReference Include="DiscordRichPresence" Version="1.3.0.28" />
     <PackageReference Include="FlaUI.UIA3" Version="4.0.0" />
-    <PackageReference Include="Hardcodet.NotifyIcon.Wpf" Version="1.1.0" />
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.65" />
+    <PackageReference Include="Hardcodet.NotifyIcon.Wpf" Version="2.0.1" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.71" />
     <PackageReference Include="Inflatable.Lastfm" Version="1.2.0" />
     <PackageReference Include="MetaBrainz.ListenBrainz" Version="4.0.0" />
     <PackageReference Include="SecureCredentialManagement" Version="1.0.2" />
-    <PackageReference Include="System.Drawing.Common" Version="9.0.0-rc.1.24451.1" />
+    <PackageReference Include="System.Drawing.Common" Version="9.0.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>


### PR DESCRIPTION
The current version of `NotifyIcon` that AMWin-RP is using is **extremely** unstable and frustrating to use, with the tooltip sometimes get stuck after (accidentally) hovering over it
![image](https://github.com/user-attachments/assets/360d3bf8-c026-4976-a8b3-39440b0cffe0)
or would get stuck at the top left edge of the screen
![5kAHbgbgwl](https://github.com/user-attachments/assets/168d247c-1857-4b6a-810b-442a73c17ef3)
It would remain there until I hover over the icon again and *hoping* it wouldn't bug out. Needless to say it happens quite often.
Moreover, it doesn't match the current style of tooltip that Windows 11 is currently using.

Upgrading `NotifyIcon` version fixes all these issues:
![image](https://github.com/user-attachments/assets/e5bd700a-402d-4747-8b42-207703da5c83)
