### PR TITLE
Fix Issue #173: Double scrobbling

### DIFF
--- a/AMWin-RichPresence/AMWin-RichPresence.csproj
+++ b/AMWin-RichPresence/AMWin-RichPresence.csproj
@@ -8,7 +8,7 @@
     <UseWPF>true</UseWPF>
     <ApplicationIcon>Resources\AMWinRP.ico</ApplicationIcon>
     <AssemblyVersion>1.0</AssemblyVersion>
-    <FileVersion>1.4.8</FileVersion>
+    <FileVersion>1.4.10</FileVersion>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <SupportedOSPlatformVersion>10.0.20348.0</SupportedOSPlatformVersion>
   </PropertyGroup>

--- a/AMWin-RichPresence/AppleMusicScrobbler.cs
+++ b/AMWin-RichPresence/AppleMusicScrobbler.cs
@@ -43,6 +43,7 @@ namespace AMWin_RichPresence {
         protected Logger? logger;
         protected string serviceName;
         protected string region;
+        protected bool scrobbleInProgress;
 
         public AppleMusicScrobbler(string serviceName, string region, Logger? logger = null) {
             this.serviceName = serviceName;
@@ -95,6 +96,7 @@ namespace AMWin_RichPresence {
                 if (thisSongID != lastSongID) {
                     lastSongID = thisSongID;
                     elapsedSeconds = 0;
+                    scrobbleInProgress = false;
                     hasScrobbled = false;
                     logger?.Log($"[{serviceName} scrobbler] New Song: {lastSongID}");
 
@@ -109,8 +111,9 @@ namespace AMWin_RichPresence {
                         logger?.Log($"[{serviceName} scrobbler] Repeating Song: {lastSongID}");
                     }
 
-                    if (IsTimeToScrobble(info) && !hasScrobbled) {
+                    if (IsTimeToScrobble(info) && !hasScrobbled && !scrobbleInProgress) {
                         logger?.Log($"[{serviceName} scrobbler] Scrobbling: {lastSongID}");
+                        scrobbleInProgress = true;
                         await ScrobbleSong(artist, album, info.SongName);
                         hasScrobbled = true;
                     }
@@ -120,6 +123,8 @@ namespace AMWin_RichPresence {
             } catch (Exception ex) {
                 logger?.Log($"[{serviceName} scrobbler] An error occurred while scrobbling: {ex}");
             }
+
+            scrobbleInProgress = false;
         }
     }
 

--- a/AMWin-RichPresence/AppleMusicScrobbler.cs
+++ b/AMWin-RichPresence/AppleMusicScrobbler.cs
@@ -113,9 +113,14 @@ namespace AMWin_RichPresence {
 
                     if (IsTimeToScrobble(info) && !hasScrobbled && !scrobbleInProgress) {
                         logger?.Log($"[{serviceName} scrobbler] Scrobbling: {lastSongID}");
-                        scrobbleInProgress = true;
-                        await ScrobbleSong(artist, album, info.SongName);
-                        hasScrobbled = true;
+
+                        try {
+                            scrobbleInProgress = true;
+                            await ScrobbleSong(artist, album, info.SongName);
+                            hasScrobbled = true;
+                        } finally {
+                            scrobbleInProgress = false;
+                        }
                     }
 
                     lastSongProgress = info.CurrentTime ?? 0.0;
@@ -123,8 +128,6 @@ namespace AMWin_RichPresence {
             } catch (Exception ex) {
                 logger?.Log($"[{serviceName} scrobbler] An error occurred while scrobbling: {ex}");
             }
-
-            scrobbleInProgress = false;
         }
     }
 


### PR DESCRIPTION
There seems to maybe be some issue with the Last.fm API that makes us to have to wait longer than the configured scrobbling interval to receive a response, which in turn causes us to fire a second scrobble call before the first one has resolved.

There may be some edge case race condition I haven't thought of, but so far this seems to be working well for me, with no double scrobbles since adding the check.