### PR TITLE
Remove status from Discord if Apple Music is closed

### DIFF
--- a/AMWin-RichPresence/App.xaml.cs
+++ b/AMWin-RichPresence/App.xaml.cs
@@ -94,29 +94,32 @@ namespace AMWin_RichPresence {
 
             // start Apple Music scraper
             amScraper = new(lastFMApiKey, Constants.RefreshPeriod, classicalComposerAsArtist, AMWin_RichPresence.Properties.Settings.Default.AppleMusicRegion, (newInfo) => {
+                // Discord RP update
+                if (AMWin_RichPresence.Properties.Settings.Default.EnableDiscordRP)
+                {
+                    discordClient.Enable();
+                    discordClient.SetPresence(newInfo,
+                        AMWin_RichPresence.Properties.Settings.Default.ShowAppleMusicIcon,
+                        AMWin_RichPresence.Properties.Settings.Default.EnableRPCoverImages);
+                }
+                else
+                {
+                    discordClient.Disable();
+                }
 
-                // don't update scraper if Apple Music is paused or not open
-                if (newInfo != null && (AMWin_RichPresence.Properties.Settings.Default.ShowRPWhenMusicPaused || !newInfo.IsPaused)) {
-
-                    // Discord RP update
-                    if (AMWin_RichPresence.Properties.Settings.Default.EnableDiscordRP) {
-                        discordClient.Enable();
-                        discordClient.SetPresence(newInfo, AMWin_RichPresence.Properties.Settings.Default.ShowAppleMusicIcon, AMWin_RichPresence.Properties.Settings.Default.EnableRPCoverImages);
-                    } else {
-                        discordClient.Disable();
-                    }
-
+                if (newInfo != null)
+                {
                     // Last.FM scrobble update
-                    if (AMWin_RichPresence.Properties.Settings.Default.LastfmEnable) {
+                    if (AMWin_RichPresence.Properties.Settings.Default.LastfmEnable)
+                    {
                         lastFmScrobblerClient.Scrobbleit(newInfo);
                     }
 
                     // ListenBrainz scrobble update
-                    if (AMWin_RichPresence.Properties.Settings.Default.ListenBrainzEnable) {
+                    if (AMWin_RichPresence.Properties.Settings.Default.ListenBrainzEnable)
+                    {
                         listenBrainzScrobblerClient.Scrobbleit(newInfo);
                     }
-                } else {
-                    discordClient.Disable();
                 }
             }, logger);
         }
@@ -129,6 +132,7 @@ namespace AMWin_RichPresence {
         private void Application_Exit(object sender, ExitEventArgs e) {
             taskbarIcon?.Dispose();
             discordClient.Disable();
+            amScraper?.Dispose();
             logger?.Log("Application finished");
         }
 

--- a/AMWin-RichPresence/AppleMusicClientScraper.cs
+++ b/AMWin-RichPresence/AppleMusicClientScraper.cs
@@ -69,14 +69,16 @@ namespace AMWin_RichPresence {
         }
     }
 
-    internal class AppleMusicClientScraper {
-        struct WebReqFailCounters {
+    internal class AppleMusicClientScraper : IDisposable
+    {
+        struct WebReqFailCounters
+        {
             public int MaxFails = Constants.NumFailedSearchesBeforeAbandon;
 
-            public int SongDuration = 0;
-            public int AlbumArt = 0;
-            public int ArtistList = 0;
-            public int SongUrl = 0;
+            public int SongDuration;
+            public int AlbumArt;
+            public int ArtistList;
+            public int SongUrl;
 
             public WebReqFailCounters() { }
         };
@@ -85,7 +87,7 @@ namespace AMWin_RichPresence {
 
         public delegate void RefreshHandler(AppleMusicInfo? newInfo);
         string? lastFmApiKey;
-        Timer timer;
+        private Timer timer;
         RefreshHandler refreshHandler;
         AppleMusicInfo? currentSong;
         public bool composerAsArtist; // for classical music, treat composer (not performer) as artist
@@ -93,8 +95,10 @@ namespace AMWin_RichPresence {
         double? previousSongProgress;
         string appleMusicRegion;
         WebReqFailCounters webReqFails = new();
+        private bool _disposed = false;
 
-        public AppleMusicClientScraper(string? lastFmApiKey, int refreshPeriodInSec, bool composerAsArtist, string appleMusicRegion, RefreshHandler refreshHandler, Logger? logger = null) {
+        public AppleMusicClientScraper(string? lastFmApiKey, int refreshPeriodInSec, bool composerAsArtist, string appleMusicRegion, RefreshHandler refreshHandler, Logger? logger = null)
+        {
             this.refreshHandler = refreshHandler;
             this.logger = logger;
             this.lastFmApiKey = lastFmApiKey;
@@ -107,19 +111,22 @@ namespace AMWin_RichPresence {
             timer.Start();
         }
 
-        ~AppleMusicClientScraper() {
-            timer.Elapsed -= Refresh;
-        }
-
-        public void ChangeRegion(string region) {
+        public void ChangeRegion(string region)
+        {
             this.appleMusicRegion = region;
             Refresh(this, null);
         }
 
-        public async void Refresh(object? source, ElapsedEventArgs? e) {
-            try {
+        public async void Refresh(object? source, ElapsedEventArgs? e)
+        {
+            if (_disposed) return;
+
+            try
+            {
                 await GetAppleMusicInfo();
-            } catch (Exception ex) {
+            }
+            catch (Exception ex)
+            {
                 logger?.Log($"Something went wrong while scraping: {ex}");
             }
             refreshHandler(currentSong);
@@ -413,6 +420,31 @@ namespace AMWin_RichPresence {
                 }
             }
             return new(songArtist, songAlbum, songPerformer);
+        }
+
+        // IDisposable implementation
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                {
+                    timer?.Stop();
+                    timer?.Dispose();
+                }
+                _disposed = true;
+            }
+        }
+
+        ~AppleMusicClientScraper()
+        {
+            Dispose(false);
         }
     }
 }

--- a/AMWin-RichPresence/AppleMusicDiscordClient.cs
+++ b/AMWin-RichPresence/AppleMusicDiscordClient.cs
@@ -44,8 +44,14 @@ internal class AppleMusicDiscordClient {
         }
     }
 
-    public void SetPresence(AppleMusicInfo amInfo, bool showSmallImage, bool showBigImage) {
+    public void SetPresence(AppleMusicInfo? amInfo, bool showSmallImage, bool showBigImage) {
         if (!enabled) {
+            return;
+        }
+
+        if (amInfo == null) {
+            client?.ClearPresence();
+            logger?.Log("Cleared Discord RP (no Apple Music running)");
             return;
         }
 


### PR DESCRIPTION
Fixes bug where if Apple Music is closed without playback being stopped it'll show you're listening to the song indefinitely.