### PR TITLE
#225 add preview options to discord client initialization

### DIFF
--- a/AMWin-RichPresence/App.xaml.cs
+++ b/AMWin-RichPresence/App.xaml.cs
@@ -75,8 +75,9 @@ namespace AMWin_RichPresence {
 
             // start Discord RPC
             var subtitleOptions = (AppleMusicDiscordClient.RPSubtitleDisplayOptions)AMWin_RichPresence.Properties.Settings.Default.RPSubtitleChoice;
+            var previewOptions = (AppleMusicDiscordClient.RPPreviewDisplayOptions)AMWin_RichPresence.Properties.Settings.Default.RPDisplayChoice;
             var classicalComposerAsArtist = AMWin_RichPresence.Properties.Settings.Default.ClassicalComposerAsArtist;
-            discordClient = new(Constants.DiscordClientID, enabled: false, subtitleOptions: subtitleOptions, logger: logger);
+            discordClient = new(Constants.DiscordClientID, enabled: false, subtitleOptions: subtitleOptions, previewOptions: previewOptions, logger: logger);
 
             // start Last.FM scrobbler
             var amRegion = AMWin_RichPresence.Properties.Settings.Default.AppleMusicRegion;


### PR DESCRIPTION
fixes #225 by adding the saved preview option to the discord client initialization, instead of only updating once the settings page is opened.