### PR TITLE
docs: sync README-JA.md with the latest English version

### DIFF
--- a/README-JA.md
+++ b/README-JA.md
@@ -1,61 +1,57 @@
-# AMWin-RP
-Apple MusicのネイティブWindowsアプリ向けのDiscord Rich Presenceクライアントです。また、Last.FMのscrobblingもサポートしています！
+# AMWin-RP 
+![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/downloads-pre/PKBeam/AMWin-RP/total) ![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/downloads-pre/PKBeam/AMWin-RP/latest/total) &nbsp; ([English](README.md) | [한국어](README-KO.md))
 
-![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/downloads-pre/PKBeam/AMWin-RP/total) ![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/downloads-pre/PKBeam/AMWin-RP/latest/total) 
+Apple MusicのネイティブWindowsアプリ向けのDiscord Rich Presenceクライアントです。
+Last.FMおよびListenBrainzでのスクロブル（再生履歴の保存）もサポートしています。
 
-![image](https://user-images.githubusercontent.com/18737124/236110561-e11eabf5-d2c4-4fb3-a743-3152a1aef916.png)
-
-![image](https://user-images.githubusercontent.com/18737124/213862194-e02ec9e7-07ab-481f-9dc5-451b9159c903.png)
+<image width=450 src="https://github.com/user-attachments/assets/df5d6a83-4630-4384-b521-bc80c286a499" />
+&nbsp; &nbsp; 
+<image src=https://github.com/user-attachments/assets/ea63ddf1-d822-4ffd-be9d-24e13701fce9 width=300 />
 
 ## インストール
+AMWin-RPは **Windows 11 24H2以降** を必要とします。
 
-リリースは[こちら](https://github.com/PKBeam/AMWin-RP/releases)で見つけることができます。
+ビルド済みファイルは[こちら](https://github.com/PKBeam/AMWin-RP/releases)で見つけることができます。
 
-もし、[.NET7.0ランタイム](https://dotnet.microsoft.com/ja-jp/download/dotnet/7.0)をインストールしているか、インストール可能であれば、NoRuntime リリースをダウンロードできます。
+### どのリリースを使えばいいですか？
+お使いのPCのプロセッサに合わせて **x64** または **ARM64** を選択してください。
+その後、標準のリリースか、`NoRuntime` とマークされたリリースのどちらかを選択します。
 
-それ以外の場合は、NoRuntimeとラベル付されていない別のリリースをダウンロードしてください。
-このリリースは、アプリケーションの実行に必要な.NET 7.0のコンポーネントをバンドルしているため、ファイルサイズが大きくなっています。
+迷った場合は、ラベルのない標準リリース（`NoRuntime` ではない方）を使用してください。
+このバージョンは、実行に必要な .NET のコンポーネントが同梱されているためファイルサイズは大きくなりますが、そのまま動作します。
+
+`NoRuntime` リリースはサイズが非常に小さいですが、[.NET 10 デスクトップランタイム](https://dotnet.microsoft.com/ja-jp/download/dotnet/10.0)がインストールされている必要があります。
+ランタイムが未インストールの状態でアプリを起動すると、インストールを促すダイアログが表示されます。
 
 ## 使用方法
-Apple Musicの[Microsoft Storeバージョン](https://apps.microsoft.com/store/detail/apple-music-preview/9PFHDD62MXS1) のみがサポートされています。
-iTunes、Apple Music via WSA、またはサードパーティのプレイヤーには対応していません。
+AMWin-RPを使用するには、[Microsoft Store版](https://apps.microsoft.com/detail/9PFHDD62MXS1)のApple Musicが必要です。
 
-このアプリはバックグラウンドで実行され、システムトレイに最小化されます。アプリを閉じるには、トレイアイコンを右クリックして「Exit」を選択します。
-リッチプレゼンスを表示するためには、Apple Musicアプリが開いており、音楽が再生中である必要があります（一時停止していない状態）。
+- `.exe` を開いてアプリを起動します。
+- AMWin-RPはバックグラウンドで実行され、システムトレイに最小化されます。
+- トレイアイコンをダブルクリックすると、設定画面が表示されます。
+    - ここから、Windows起動時の自動実行、スクロブル、曲検出などの設定を行えます。
+- アプリを終了するには、トレイアイコンを右クリックして「Exit」を選択します。
+- デフォルトでは、Rich Presenceを表示するために、Apple Musicアプリが開いており、音楽が再生中である（一時停止していない）必要があります。
 
-お好みでアプリをWindows起動時に自動的に実行する設定を行うこともできます。これはトレイアイコンをダブルクリックして設定を変更することで行えます。
+**注意**: 仮想デスクトップを使用している場合、AMWin-RPとApple Musicは**同じデスクトップ**に配置されている必要があります。これは、Apple Musicクライアントから情報を取得するために使用しているUI Automationライブラリの技術的な制限によるものです。
 
-<hr/>
+## スクロブル
+このスクロブラーの実装はオフラインでのスクロブルをサポートしていません。インターネットに接続されていない状態で聴いた曲の履歴は保存されませんのでご注意ください。
 
-## Last.FMでのScrobbling
-Last.FMへのScrobblingがサポートされています。Last.FMのAPI KeyとSecret Keyを取得する必要があります。これを生成するには、[https://www.last.fm/api](https://www.last.fm/api) にアクセスし、「Get an API account」を選択してください。これらの情報とLast.FMのユーザー名とパスワードを使用してください：
+### Last.FM
+Last.FMから独自のAPI KeyとAPI Secretを取得する必要があります。
+[https://www.last.fm/api](https://www.last.fm/api) にアクセスし、「Get an API account」から生成してください。
+取得した情報を、Last.FMのユーザー名とパスワードとともに設定メニューで入力してください。
 
-![AMWin-RP-Scrobbler_Settings](https://user-images.githubusercontent.com/317772/215867741-2999591c-35eb-442a-a349-b8e9046634fb.png)
+Last.FMのパスワードは、ローカルWindowsアカウントの[Windows資格情報マネージャー](https://support.microsoft.com/ja-jp/windows/%E8%B3%87%E6%A0%BC%E6%83%85%E5%A0%B1%E3%83%9E%E3%83%8D%E3%83%BC%E3%82%B8%E3%83%A3%E3%83%BC%E3%81%AB%E3%82%A2%E3%82%AF%E3%82%BB%E3%82%B9%E3%81%99%E3%82%8B-1b5c916a-6a16-889f-8581-fc16e8165ac0)に保存されます。
 
-Last.FMのパスワードは、ローカルWindowsアカウントの[Windows資格情報マネージャ](https://support.microsoft.com/ja-jp/windows/%E8%B3%87%E6%A0%BC%E6%83%85%E5%A0%B1%E3%83%9E%E3%83%8D%E3%83%BC%E3%82%B8%E3%83%A3%E3%83%BC%E3%81%AB%E3%82%A2%E3%82%AF%E3%82%BB%E3%82%B9%E3%81%99%E3%82%8B-1b5c916a-6a16-889f-8581-fc16e8165ac0)に保存されています。
+### ListenBrainz
+設定でユーザートークンを追加することで、ListenBrainzへのスクロブルが可能です。
 
-このScrobbling実装ではオフラインScrobblingをサポートしていないため、インターネットに接続していない状態で聴いた曲は失われます。
+## バグ報告
+新しくIssueを作成する前に、同様の問題が既に報告されていないか確認してください。
+問題を報告する際は、関連するログファイル（`%localappdata%\AMWin-RichPresence` にあります）を添付してください。
 
-
-<hr/>
-
-
-## どのように動作しているのでしょうか？
-
-**(技術的な詳細が続きます)**
-
-この最大の課題は、Apple Musicアプリから曲の情報を抽出できるようにすることです。
-
-これは.NETの[UI オートメーション](https://learn.microsoft.com/ja-jp/dotnet/framework/ui-automation/ui-automation-overview)を使用して実現されます。これにより、ユーザーのデスクトップ上の任意のウィンドウのUI要素にアクセスできます。
-
-一般的なプロセスは次のとおりです：
-- デスクトップ上でApple Musicウィンドウを探します。
-- 次に、我々は望んでいる情報を保持する既知のUIコントロールに移動します（たとえば、曲名など）。
-- この情報を抽出し、Discord RPCを処理するプログラムの一部に送信します。
-
-もう1つの問題は、曲のカバーアートを取得することです。
-
-あまり文書化されていませんが、Discord RPCではassets keyの代わりに画像の URL を送信することで、任意の画像を指定できるようになりました。）
-
-私の知る限り、UI オートメーションを使用してウィンドウに表示されている画像を取得することはできません。代わりに、Apple MusicのウェブサイトにHTTPリクエストを送信し、そこから曲を検索してカバー画像のURLを取得しようとします。理想的ではありませんが、ほとんどの場合、我々が求めているものを提供してくれます。
-
+投稿前に、以下の項目を再確認してください：
+- 同様の問題が、オープンまたはクローズされたIssueに存在しないか。
+- Discordの設定でRich Presenceの表示が有効になっているか（設定 > アクティビティ設定 > アクティビティのプライバシー > アクティビティを共有）。


### PR DESCRIPTION
Hello! I noticed that the Japanese README was outdated compared to the main README.md. This PR updates the translation to sync with the latest English version.
Changes included:
- Added Windows 11 24H2 requirement
- Updated .NET version from 7.0 to 10
- Added x64/ARM64 selection guide
- Added ListenBrainz scrobbling section
- Added virtual desktop warning note
- Added bug reporting section