### PR TITLE
Spanish localisation

### DIFF
--- a/AMWin-RichPresence/App.xaml.cs
+++ b/AMWin-RichPresence/App.xaml.cs
@@ -1,4 +1,4 @@
-﻿using Hardcodet.Wpf.TaskbarNotification;
+﻿﻿using Hardcodet.Wpf.TaskbarNotification;
 using System;
 using System.Diagnostics;
 using System.Globalization;
@@ -32,6 +32,8 @@ namespace AMWin_RichPresence {
                 "tr" => "tr",
                 "ko" => "ko",
                 "ja" => "ja",
+                "ru" => "ru",
+                "es" => "es",
                 _ => ""
             };
         }

--- a/AMWin-RichPresence/Properties/Localisation.es.resx
+++ b/AMWin-RichPresence/Properties/Localisation.es.resx
@@ -1,17 +1,17 @@
-﻿﻿<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -118,237 +118,237 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Settings_General_UpdateOnStartup" xml:space="preserve">
-    <value>시작 시 업데이트 확인</value>
+    <value>Comprobar actualizaciones al iniciar</value>
   </data>
   <data name="Settings_General_ComposerAsArtist" xml:space="preserve">
-    <value>작곡가를 아티스트로 표시</value>
+    <value>Considerar al compositor como artista</value>
   </data>
   <data name="Settings_General_RunOnWindowsStartup" xml:space="preserve">
-    <value>Windows 시작 시 실행</value>
+    <value>Ejecutar al iniciar Windows</value>
   </data>
   <data name="Settings_General_AppleMusicRegion" xml:space="preserve">
-    <value>Apple Music 지역</value>
+    <value>Región de Apple Music</value>
   </data>
   <data name="Settings_Discord_SectionTitle" xml:space="preserve">
     <value>Discord Rich Presence</value>
   </data>
   <data name="Settings_Discord_EnableRP" xml:space="preserve">
-    <value>Discord Rich Presence 사용</value>
+    <value>Habilitar Discord Rich Presence</value>
   </data>
   <data name="Settings_Discord_ShowAlbumArt" xml:space="preserve">
-    <value>앨범 아트 표시</value>
+    <value>Mostrar portada del álbum</value>
   </data>
   <data name="Settings_Discord_ShowWhenPaused" xml:space="preserve">
-    <value>음악이 일시정지되어도 표시</value>
+    <value>Mostrar cuando la música está pausada</value>
   </data>
   <data name="Settings_Discord_ShowAppleMusicIcon" xml:space="preserve">
-    <value>Apple Music 아이콘 표시</value>
+    <value>Mostrar icono de Apple Music</value>
   </data>
   <data name="Settings_Discord_UserStatusDisplay" xml:space="preserve">
-    <value>Discord 상태 표시 방식</value>
+    <value>Mostrar estado de Discord como</value>
   </data>
   <data name="Settings_Discord_UserStatusDisplay_Artist" xml:space="preserve">
-    <value>아티스트 이름</value>
+    <value>Nombre del artista</value>
   </data>
   <data name="Settings_Discord_UserStatusDisplay_SongName" xml:space="preserve">
-    <value>곡 이름</value>
+    <value>Título de la canción</value>
   </data>
   <data name="Settings_Discord_UserStatusDisplay_AppleMusic" xml:space="preserve">
     <value>Apple Music</value>
   </data>
   <data name="Settings_Discord_Lyrics_SectionTitle" xml:space="preserve">
-    <value>동기화 가사 (실험 기능)</value>
+    <value>Letra Sincronizada</value>
   </data>
   <data name="Settings_Discord_Lyrics_EnableLyrics" xml:space="preserve">
-    <value>Rich Presence에 가사 표시</value>
+    <value>Mostrar letra de la canción en Rich Presence</value>
   </data>
   <data name="Settings_Discord_Lyrics_ShowDuringBreak" xml:space="preserve">
-    <value>연주 구간에도 가사 유지</value>
+    <value>Mantener letra en secciones instrumentales</value>
   </data>
   <data name="Settings_Discord_Lyrics_OpenCache" xml:space="preserve">
-    <value>가사 캐시 열기</value>
+    <value>Abrir caché de letras</value>
   </data>
   <data name="Settings_Discord_Lyrics_ClearCache" xml:space="preserve">
-    <value>가사 캐시 비우기</value>
+    <value>Limpiar caché de letras</value>
   </data>
   <data name="Settings_Scrobbling_SectionTitle" xml:space="preserve">
-    <value>스크로블링</value>
+    <value>Scrobbling</value>
   </data>
   <data name="Settings_Scrobbling_CleanAlbumName" xml:space="preserve">
-    <value>앨범 이름 정리</value>
+    <value>Limpiar nombre del álbum</value>
   </data>
   <data name="Settings_Scrobbling_ScrobblePrimaryArtist" xml:space="preserve">
-    <value>첫 번째 아티스트만 스크로블</value>
+    <value>Solo scrobblear el primer artista</value>
   </data>
   <data name="Settings_Scrobbling_SongDurationChoice" xml:space="preserve">
-    <value>Apple Music 웹사이트의 곡 길이 사용</value>
+    <value>Usar la duración de la canción de la web de Apple Music</value>
   </data>
   <data name="Settings_Scrobbling_ScrobbleTime" xml:space="preserve">
-    <value>최대 스크로블 대기 시간:</value>
+    <value>Máxima espera para scrobblear:</value>
   </data>
   <data name="Settings_Scrobbling_LastFM_SectionTitle" xml:space="preserve">
     <value>Last.FM</value>
   </data>
   <data name="Settings_Scrobbling_LastFM_ApiKey" xml:space="preserve">
-    <value>API 키</value>
+    <value>Clave API</value>
   </data>
   <data name="Settings_Scrobbling_LastFM_ApiSecret" xml:space="preserve">
-    <value>API 시크릿</value>
+    <value>API Secret</value>
   </data>
   <data name="Settings_Scrobbling_LastFM_Username" xml:space="preserve">
-    <value>사용자 이름</value>
+    <value>Nombre de usuario</value>
   </data>
   <data name="Settings_Scrobbling_LastFM_Password" xml:space="preserve">
-    <value>비밀번호</value>
+    <value>Contraseña</value>
   </data>
   <data name="Settings_Scrobbling_ListenBrainz_SectionTitle" xml:space="preserve">
     <value>ListenBrainz</value>
   </data>
   <data name="Settings_Scrobbling_ListenBrainz_UserToken" xml:space="preserve">
-    <value>사용자 토큰</value>
+    <value>Token de usuario</value>
   </data>
   <data name="Settings_Scrobbling_LastFM_Enable" xml:space="preserve">
-    <value>Last.FM 스크로블링 사용</value>
+    <value>Habilitar scrobbling de Last.FM</value>
   </data>
   <data name="Settings_Scrobbling_ListenBrainz_Enable" xml:space="preserve">
-    <value>ListenBrainz 스크로블링 사용</value>
+    <value>Habilitar scrobbling de ListenBrainz</value>
   </data>
   <data name="Settings_Scrobbling_LastFM_SaveCredentials" xml:space="preserve">
-    <value>자격 증명 저장</value>
+    <value>Guardar credenciales</value>
   </data>
   <data name="Message_ClearLyricCache" xml:space="preserve">
-    <value>저장된 가사를 모두 삭제하시겠습니까?</value>
+    <value>¿Estás seguro de eliminar todas las letras guardadas?</value>
   </data>
   <data name="Message_ClearLyricCache_Title" xml:space="preserve">
-    <value>캐시된 가사 삭제</value>
+    <value>Eliminar letras en caché</value>
   </data>
   <data name="Message_ClearedLyricCache" xml:space="preserve">
-    <value>저장된 가사가 모두 삭제되었습니다.</value>
+    <value>Todas las letras guardadas han sido eliminadas.</value>
   </data>
   <data name="Message_ClearedLyricCache_Title" xml:space="preserve">
-    <value>가사 삭제 완료</value>
+    <value>Letras Eliminadas</value>
   </data>
   <data name="Message_ClearLyricCache_Fail" xml:space="preserve">
-    <value>가사를 삭제할 수 없습니다: </value>
+    <value>No se logró eliminar las letars: </value>
   </data>
   <data name="Message_Error" xml:space="preserve">
-    <value>오류</value>
+    <value>Error</value>
   </data>
   <data name="Message_ClearLyricCache_FailNotFound" xml:space="preserve">
-    <value>저장된 가사를 찾을 수 없습니다.</value>
+    <value>No se han encontrado letras guardadas.</value>
   </data>
   <data name="Message_Information" xml:space="preserve">
-    <value>정보</value>
+    <value>Información</value>
   </data>
   <data name="Message_LastFM_Authentication_Title" xml:space="preserve">
-    <value>Last.FM 인증</value>
+    <value>Autenticación de Last.FM</value>
   </data>
   <data name="Message_LastFM_Authentication_Fail" xml:space="preserve">
-    <value>Last.FM 자격 증명을 인증할 수 없습니다. 사용자 이름과 비밀번호를 확인하고 계정이 잠겨 있지 않은지 확인하세요.</value>
+    <value>Las credenciales de Last.FM no han podido ser autenticadas. Por favor asegúrate de haber introducido correctamente el usuario y contraseña, y que su cuenta no esté actualmente bloqueada.</value>
   </data>
   <data name="Message_ListenBrainz_Authentication_Title" xml:space="preserve">
-    <value>ListenBrainz 인증</value>
+    <value>Autenticación de ListenBrainz</value>
   </data>
   <data name="Message_LastFM_Authentication_Success" xml:space="preserve">
-    <value>Last.FM 자격 증명이 인증되었습니다.</value>
+    <value>Se han autenticado exitosamente las credenciales de Last.FM.</value>
   </data>
   <data name="Message_ListenBrainz_Authentication_Fail" xml:space="preserve">
-    <value>ListenBrainz 자격 증명을 인증할 수 없습니다. 사용자 토큰을 확인하세요.</value>
+    <value>Las credenciales de ListenBrainz no han podido ser autenticadas. Por favor asegúrate de haber introducido correctamente el token de usuario.</value>
   </data>
   <data name="Message_ListenBrainz_Authentication_Success" xml:space="preserve">
-    <value>ListenBrainz 자격 증명이 인증되었습니다.</value>
+    <value>Se han autenticado exitosamente las credenciales de ListenBrainz.</value>
   </data>
   <data name="DiscordButton_ListenOnAppleMusic" xml:space="preserve">
-    <value>Apple Music에서 듣기</value>
+    <value>Escuchar en Apple Music</value>
   </data>
   <data name="DiscordButton_ViewArtist" xml:space="preserve">
-    <value>아티스트 보기</value>
+    <value>Ver Artista</value>
   </data>
   <data name="Message_AppUpdate_Title" xml:space="preserve">
-    <value>새 업데이트 사용 가능</value>
+    <value>Nueva actualización disponible</value>
   </data>
   <data name="Message_AppUpdate" xml:space="preserve">
-    <value>AMWin-RP의 새 업데이트가 있습니다. 릴리스 페이지를 보시겠습니까?</value>
+    <value>Una nueva actualización para AMWin-RP está disponible. ¿Te gustaría ver las versiones?</value>
   </data>
   <data name="Settings_Title" xml:space="preserve">
-    <value>설정</value>
+    <value>Ajustes</value>
   </data>
   <data name="Settings_TimeUnitSeconds" xml:space="preserve">
-    <value>초</value>
+    <value>segundos</value>
   </data>
   <data name="Settings_General_TooltipAppleMusicRegionError" xml:space="preserve">
-    <value>입력한 값이 Apple Music의 유효한 지역 코드가 아닙니다.</value>
+    <value>Código de región no válido</value>
   </data>
   <data name="Settings_General_ComposerAsArtist_Description" xml:space="preserve">
-    <value>클래식 트랙에서 연주자 대신 작곡가를 아티스트로 사용합니다.</value>
+    <value>Para piezas de música clásica, utilizar el compositor como artista en lugar del intérprete.</value>
   </data>
   <data name="Settings_Discord_ShowAppleMusicIcon_Description" xml:space="preserve">
-    <value>Rich Presence에서 앨범 아트 옆에 Apple Music 아이콘을 표시합니다.</value>
+    <value>Muestra el icono de Apple Music junto a la portada del álbum en el Rich Presence display.</value>
   </data>
   <data name="Settings_Discord_Lyrics_ShowDuringBreak_Description" xml:space="preserve">
-    <value>음악의 공백 구간에서도 마지막 가사 줄을 계속 표시합니다.</value>
+    <value>Durante los silencios en la música, seguir mostrando las últimas letras cantadas.</value>
   </data>
   <data name="Settings_General_AppleMusicRegion_Description" xml:space="preserve">
-    <value>Apple 계정 지역의 국가 코드입니다 (예: KR).</value>
+    <value>El código de región de tu cuenta de Apple (e.g. ES).</value>
   </data>
   <data name="Settings_Scrobbling_SongDurationChoice_Description" xml:space="preserve">
-    <value>Last.FM 대신 Apple Music 웹사이트에서 곡 길이를 가져옵니다. 더 느리지만 더 정확할 수 있습니다.</value>
+    <value>Obtener la duración de la canción del sitio web de Apple Music en lugar del sitio web de Last.FM. Más lento, pero puede ofrecer mejores resultados.</value>
   </data>
   <data name="Settings_Scrobbling_ScrobbleTime_Description" xml:space="preserve">
-    <value>이 시간이 지나면 아직 스크로블되지 않은 곡을 스크로블합니다.</value>
+    <value>Tras este periodo de tiempo, scrobblea la canción si no ha sido scrobbleada todavía.</value>
   </data>
   <data name="Message_Yes" xml:space="preserve">
-    <value>예</value>
+    <value>Sí</value>
   </data>
   <data name="Message_No" xml:space="preserve">
-    <value>아니요</value>
+    <value>No</value>
   </data>
   <data name="Settings_General_SectionTitle" xml:space="preserve">
-    <value>일반</value>
+    <value>General</value>
   </data>
   <data name="Settings_Discord_SectionTitleShort" xml:space="preserve">
     <value>Discord RP</value>
   </data>
   <data name="Settings_Scrobbling_CleanAlbumName_Description" xml:space="preserve">
-    <value>앨범 이름에서 "Single", "EP" 같은 일반 접미사를 제거합니다.</value>
+    <value>Elimina sufijos comunes como "Single" y "EP" del nombre de los álbumes.</value>
   </data>
   <data name="Taskbar_Settings_Title" xml:space="preserve">
-    <value>설정</value>
+    <value>Ajustes</value>
   </data>
   <data name="Taskbar_Exit_Title" xml:space="preserve">
-    <value>종료</value>
+    <value>Salir</value>
   </data>
   <data name="Settings_General_Language" xml:space="preserve">
-    <value>언어</value>
+    <value>Idioma</value>
   </data>
   <data name="Settings_General_Language_Description" xml:space="preserve">
-    <value>언어를 변경한 후 앱을 다시 시작해야 완전히 적용됩니다.</value>
+    <value>Reinicia la app después de cambiar el idioma para aplicar correctamente los cambios.</value>
   </data>
   <data name="Settings_General_Language_System" xml:space="preserve">
-    <value>시스템 기본값 (System default)</value>
+    <value>Por defecto del sistema (Por defecto del sistema)</value>
   </data>
   <data name="Settings_General_Language_English" xml:space="preserve">
-    <value>영어 (English)</value>
+    <value>Inglés (English)</value>
   </data>
   <data name="Settings_General_Language_Turkish" xml:space="preserve">
-    <value>터키어 (Türkçe)</value>
+    <value>Turco (Türkçe)</value>
   </data>
   <data name="Settings_General_Language_Korean" xml:space="preserve">
-    <value>한국어 (한국어)</value>
+    <value>Coreano (한국어)</value>
   </data>
   <data name="Settings_General_Language_Japanese" xml:space="preserve">
-    <value>일본어 (日本語)</value>
+    <value>Japonés (日本語)</value>
   </data>
-    <data name="Settings_General_Language_Russian" xml:space="preserve">
-    <value>러시아 (Русский)</value>
+  <data name="Settings_General_Language_Russian" xml:space="preserve">
+    <value>Ruso (Русский)</value>
   </data>
   <data name="Settings_General_Language_Spanish" xml:space="preserve">
-    <value>스페인어 (Español)</value>
+    <value>Español (Español)</value>
   </data>
   <data name="Message_RestartRequired_Title" xml:space="preserve">
-    <value>다시 시작 필요</value>
+    <value>Se Requiere Reiniciar</value>
   </data>
   <data name="Message_RestartRequired_Content" xml:space="preserve">
-    <value>언어 변경을 적용하려면 지금 다시 시작할까요?</value>
+    <value>¿Reiniciar ahora para aplicar el cambio de idioma?</value>
   </data>
 </root>

--- a/AMWin-RichPresence/Properties/Localisation.ja.resx
+++ b/AMWin-RichPresence/Properties/Localisation.ja.resx
@@ -1,17 +1,17 @@
-﻿﻿<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->

--- a/AMWin-RichPresence/Properties/Localisation.ja.resx
+++ b/AMWin-RichPresence/Properties/Localisation.ja.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+﻿﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -338,6 +338,12 @@
   </data>
   <data name="Settings_General_Language_Japanese" xml:space="preserve">
     <value>日本語 (日本語)</value>
+  </data>
+  <data name="Settings_General_Language_Russian" xml:space="preserve">
+    <value>ロシア語 (Русский)</value>
+  </data>
+  <data name="Settings_General_Language_Spanish" xml:space="preserve">
+    <value>スペイン語 (Español)</value>
   </data>
   <data name="Message_RestartRequired_Title" xml:space="preserve">
     <value>再起動が必要です</value>

--- a/AMWin-RichPresence/Properties/Localisation.ko.resx
+++ b/AMWin-RichPresence/Properties/Localisation.ko.resx
@@ -1,17 +1,17 @@
-﻿﻿<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->

--- a/AMWin-RichPresence/Properties/Localisation.resx
+++ b/AMWin-RichPresence/Properties/Localisation.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+﻿﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -338,6 +338,12 @@
   </data>
   <data name="Settings_General_Language_Japanese" xml:space="preserve">
     <value>Japanese (日本語)</value>
+  </data>
+  <data name="Settings_General_Language_Russian" xml:space="preserve">
+    <value>Russian (Русский)</value>
+  </data>
+  <data name="Settings_General_Language_Spanish" xml:space="preserve">
+    <value>Spanish (Español)</value>
   </data>
   <data name="Message_RestartRequired_Title" xml:space="preserve">
     <value>Restart Required</value>

--- a/AMWin-RichPresence/Properties/Localisation.resx
+++ b/AMWin-RichPresence/Properties/Localisation.resx
@@ -1,17 +1,17 @@
-﻿﻿<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->

--- a/AMWin-RichPresence/Properties/Localisation.tr.resx
+++ b/AMWin-RichPresence/Properties/Localisation.tr.resx
@@ -1,17 +1,17 @@
-﻿﻿<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->

--- a/AMWin-RichPresence/Properties/Localisation.tr.resx
+++ b/AMWin-RichPresence/Properties/Localisation.tr.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+﻿﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -338,6 +338,12 @@
   </data>
   <data name="Settings_General_Language_Japanese" xml:space="preserve">
     <value>Japonca (日本語)</value>
+  </data>
+  <data name="Settings_General_Language_Russian" xml:space="preserve">
+    <value>Rusça (Русский)</value>
+  </data>
+  <data name="Settings_General_Language_Spanish" xml:space="preserve">
+    <value>İspanyolca (Español)</value>
   </data>
   <data name="Message_RestartRequired_Title" xml:space="preserve">
     <value>Yeniden baslatma gerekli</value>

--- a/AMWin-RichPresence/SettingsWindow.xaml
+++ b/AMWin-RichPresence/SettingsWindow.xaml
@@ -1,4 +1,4 @@
-﻿<ui:FluentWindow 
+﻿<ui:FluentWindow
     x:Class="AMWin_RichPresence.SettingsWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -45,7 +45,7 @@
                         x:Name="NavItemDiscord"
                         Content="{x:Static properties:Localisation.Settings_Discord_SectionTitleShort}"
                         Icon="{ui:SymbolIcon XboxController48}" 
-                        Click="NavItemDiscord_Click"/>
+                       Click="NavItemDiscord_Click"/>
                     <ui:NavigationViewItem
                         x:Name="NavItemScrobbling"
                         Content="{x:Static properties:Localisation.Settings_Scrobbling_SectionTitle}"
@@ -66,13 +66,13 @@
                                     x:Name="CheckBox_RunOnStartup" 
                                     IsChecked="{Binding Source={x:Static properties:Settings.Default}, Path=RunOnStartup, Mode=TwoWay}" 
                                     Click="CheckBox_RunOnStartup_Click" 
-                                    Content="{x:Static properties:Localisation.Settings_General_RunOnWindowsStartup}"/>
+                                 Content="{x:Static properties:Localisation.Settings_General_RunOnWindowsStartup}"/>
 
                                 <CheckBox
-                                    x:Name="CheckBox_CheckForUpdatesOnStartup" 
+                                       x:Name="CheckBox_CheckForUpdatesOnStartup" 
                                     IsChecked="{Binding Source={x:Static properties:Settings.Default}, Path=CheckForUpdatesOnStartup, Mode=TwoWay}" 
                                     Click="CheckBox_CheckForUpdatesOnStartup_Click" 
-                                    Content="{x:Static properties:Localisation.Settings_General_UpdateOnStartup}"/>
+                                 Content="{x:Static properties:Localisation.Settings_General_UpdateOnStartup}"/>
 
                                 <CheckBox
                                     x:Name="CheckBox_ClassicalComposerAsArtist" 
@@ -81,7 +81,7 @@
                                     Content="{x:Static properties:Localisation.Settings_General_ComposerAsArtist}"/>
                                 
                                 <TextBlock 
-                                    Margin="40 0 0 10" FontSize="12"  VerticalAlignment="Center" TextWrapping="Wrap"
+   Margin="40 0 0 10" FontSize="12"  VerticalAlignment="Center" TextWrapping="Wrap"
                                     Text="{x:Static properties:Localisation.Settings_General_ComposerAsArtist_Description}"/>
 
                                 <StackPanel Orientation="Horizontal" Margin="10 10 0 2">
@@ -128,34 +128,33 @@
                                 <TextBlock
                                     x:Name="SectionTitleDiscord"
                                     FontSize="18" FontWeight="Bold" Padding="0 15 0 5" Margin="0 10 0 7" VerticalAlignment="Top" 
-                                    Text="{x:Static properties:Localisation.Settings_Discord_SectionTitle}"/>
+                                   Text="{x:Static properties:Localisation.Settings_Discord_SectionTitle}"/>
 
-                                <CheckBox 
+                                 <CheckBox 
                                     x:Name="CheckBox_EnableDiscordRP" 
                                     IsChecked="{Binding Source={x:Static properties:Settings.Default}, Path=EnableDiscordRP, Mode=TwoWay}" 
                                     Click="CheckBox_EnableDiscordRP_Click" 
-                                    Content="{x:Static properties:Localisation.Settings_Discord_EnableRP}"/>
+                               Content="{x:Static properties:Localisation.Settings_Discord_EnableRP}"/>
 
-                                <CheckBox 
+                                     <CheckBox 
                                     x:Name="CheckBox_EnableRPCoverImages" 
                                     IsEnabled="{Binding IsChecked, ElementName=CheckBox_EnableDiscordRP}" 
                                     IsChecked="{Binding Source={x:Static properties:Settings.Default}, Path=EnableRPCoverImages, Mode=TwoWay}" 
                                     Click="CheckBox_EnableRPCoverImages_Click" 
-                                    Content="{x:Static properties:Localisation.Settings_Discord_ShowAlbumArt}"/>
+                          Content="{x:Static properties:Localisation.Settings_Discord_ShowAlbumArt}"/>
 
                                 <CheckBox
-                                    x:Name="CheckBox_ShowRPWhenMusicPaused" 
+                                              x:Name="CheckBox_ShowRPWhenMusicPaused" 
                                     IsEnabled="{Binding IsChecked, ElementName=CheckBox_EnableDiscordRP}" 
                                     IsChecked="{Binding Source={x:Static properties:Settings.Default}, Path=ShowRPWhenMusicPaused, Mode=TwoWay}" 
                                     Click="CheckBox_ShowRPWhenMusicPaused_Click" 
-                                    Content="{x:Static properties:Localisation.Settings_Discord_ShowWhenPaused}"/>
+                      Content="{x:Static properties:Localisation.Settings_Discord_ShowWhenPaused}"/>
 
-                                <CheckBox 
+                                              <CheckBox 
                                     x:Name="CheckBox_ShowAppleMusicIcon" 
                                     IsEnabled="{Binding IsChecked, ElementName=CheckBox_EnableDiscordRP}" 
                                     IsChecked="{Binding Source={x:Static properties:Settings.Default}, Path=ShowAppleMusicIcon, Mode=TwoWay}" 
                                     Click="CheckBox_ShowAppleMusicIcon_Click" 
-                                    Content="{x:Static properties:Localisation.Settings_Discord_ShowAppleMusicIcon}"/>
                                 <TextBlock 
                                     Margin="40 0 0 10" FontSize="12"  VerticalAlignment="Center" TextWrapping="Wrap"
                                     Text="{x:Static properties:Localisation.Settings_Discord_ShowAppleMusicIcon_Description}"/>
@@ -163,13 +162,13 @@
                                 <StackPanel Orientation="Horizontal" Margin="10 7 0 7">
                                     <TextBlock 
                                         VerticalAlignment="Center" 
-                                        Margin="0 0 10 2"
+                                      Margin="0 0 10 2"
                                         Text="{x:Static properties:Localisation.Settings_Discord_UserStatusDisplay}"/>
-                                    <ComboBox 
+                                      <ComboBox 
                                         x:Name="ComboBox_RPDisplayChoice" 
                                         IsEnabled="{Binding IsChecked, ElementName=CheckBox_EnableDiscordRP}" 
                                         SelectedIndex="{Binding Source={x:Static properties:Settings.Default}, Path=RPDisplayChoice, Mode=TwoWay}" 
-                                        SelectionChanged="ComboBox_RPDisplayChoice_SelectionChanged">
+                                  SelectionChanged="ComboBox_RPDisplayChoice_SelectionChanged">
                                         <!-- The order of these items matters! (check the enum in AppleMusicDiscordClient.cs) -->
                                         <ComboBoxItem Content="{x:Static properties:Localisation.Settings_Discord_UserStatusDisplay_Artist}"/>
                                         <ComboBoxItem Content="{x:Static properties:Localisation.Settings_Discord_UserStatusDisplay_AppleMusic}"/>
@@ -181,25 +180,25 @@
                                 <ui:Card Margin="0 15 0 5">
                                     <StackPanel>
                                         <DockPanel Margin="0 0 0 7">
-                                            <TextBlock 
+                                                  <TextBlock 
                                                 FontSize="16" FontWeight="SemiBold" VerticalAlignment="Top" 
-                                                IsEnabled="{Binding IsChecked, ElementName=CheckBox_EnableDiscordRP}"
+                                        IsEnabled="{Binding IsChecked, ElementName=CheckBox_EnableDiscordRP}"
                                                 Text="{x:Static properties:Localisation.Settings_Discord_Lyrics_SectionTitle}"/>
                                             <StackPanel HorizontalAlignment="Right">
-                                                <ui:ToggleSwitch 
+                                                        <ui:ToggleSwitch 
                                                     x:Name="CheckBox_EnableSyncLyrics" 
                                                     IsChecked="{Binding Source={x:Static properties:Settings.Default}, Path=EnableSyncLyrics, Mode=TwoWay}" 
-                                                    Click="CheckBox_EnableSyncLyrics_Click"/>
+                                         Click="CheckBox_EnableSyncLyrics_Click"/>
                                             </StackPanel>
                                         </DockPanel>
 
-                                        <TextBlock 
-                                            Margin="0 0 0 15" FontSize="12"  VerticalAlignment="Center" TextWrapping="Wrap"
+                                                   <TextBlock 
+                                Margin="0 0 0 15" FontSize="12"  VerticalAlignment="Center" TextWrapping="Wrap"
                                             Text="{x:Static properties:Localisation.Settings_Discord_Lyrics_EnableLyrics}"/>
-                                        
+
+                                                   
                                         <CheckBox 
                                             x:Name="CheckBox_ExtendLyricsLine" 
-                                            IsEnabled="{Binding IsChecked, ElementName=CheckBox_EnableSyncLyrics}"
                                             IsChecked="{Binding Source={x:Static properties:Settings.Default}, Path=ExtendLyricsLine, Mode=TwoWay}" 
                                             Click="CheckBox_ExtendLyricsLine_Click" 
                                             Content="{x:Static properties:Localisation.Settings_Discord_Lyrics_ShowDuringBreak}"/>
@@ -213,58 +212,53 @@
                                                 Content="{x:Static properties:Localisation.Settings_Discord_Lyrics_OpenCache}" 
                                                 Click="Button_OpenLyricCache_Click" />
                                             <Button 
-                                                x:Name="Button_DeleteLyricCache"
-                                                Content="{x:Static properties:Localisation.Settings_Discord_Lyrics_ClearCache}" 
-                                                Click="Button_DeleteLyricCache_Click"/>
                                         </StackPanel>   
-                                    </StackPanel>
+                                 </StackPanel>
                                 </ui:Card>
-                                
-                                <!-- Scrobbling settings -->
                                 <TextBlock 
-                                    x:Name="SectionTitleScrobbling"
-                                    Padding="0 15 0 5" Margin="0 20 0 7" FontWeight="Bold" FontSize="18" 
-                                    Text="{x:Static properties:Localisation.Settings_Scrobbling_SectionTitle}"/>
+                                   x:Name="SectionTitleScrobbling"
+                                     Padding="0 15 0 5" Margin="0 20 0 7" FontWeight="Bold" FontSize="18" 
+                                  Text="{x:Static properties:Localisation.Settings_Scrobbling_SectionTitle}"/>
 
                                 <CheckBox 
                                     x:Name="CheckBox_LastfmCleanAlbumName"
-                                    IsChecked="{Binding Source={x:Static properties:Settings.Default}, Path=LastfmCleanAlbumName, Mode=TwoWay}" 
+                                      IsChecked="{Binding Source={x:Static properties:Settings.Default}, Path=LastfmCleanAlbumName, Mode=TwoWay}" 
                                     Click="CheckBox_LastfmCleanAlbumName_Click" 
-                                    Content="{x:Static properties:Localisation.Settings_Scrobbling_CleanAlbumName}"/>
-                                <TextBlock 
-                                    Margin="40 0 0 10" FontSize="12"  VerticalAlignment="Center" TextWrapping="Wrap"
+                                Content="{x:Static properties:Localisation.Settings_Scrobbling_CleanAlbumName}"/>
+                                    <TextBlock 
+                               Margin="40 0 0 10" FontSize="12"  VerticalAlignment="Center" TextWrapping="Wrap"
                                     Text="{x:Static properties:Localisation.Settings_Scrobbling_CleanAlbumName_Description}"/>
 
-                                <CheckBox 
+                                     <CheckBox 
                                     x:Name="CheckBox_LastfmScrobblePrimary" Margin="0 2 0 0" 
                                     IsChecked="{Binding Source={x:Static properties:Settings.Default}, Path=LastfmScrobblePrimaryArtist, Mode=TwoWay}" 
                                     Click="CheckBox_LastfmScrobblePrimary_Click" 
-                                    Content="{x:Static properties:Localisation.Settings_Scrobbling_ScrobblePrimaryArtist}"/>
+                           Content="{x:Static properties:Localisation.Settings_Scrobbling_ScrobblePrimaryArtist}"/>
 
-                                <CheckBox 
+                                         <CheckBox 
                                     x:Name="CheckBox_ScrobblePreferAppleMusicWebDuration" 
                                     Margin="0 2 0 0" IsChecked="{Binding Source={x:Static properties:Settings.Default}, Path=ScrobblePreferAppleMusicWebDuration, Mode=TwoWay}" 
-                                    Checked="CheckBox_ScrobblePreferAppleMusicWebDuration_Checked"
+                        Checked="CheckBox_ScrobblePreferAppleMusicWebDuration_Checked"
                                     Content="{x:Static properties:Localisation.Settings_Scrobbling_SongDurationChoice}"/>
-                                <TextBlock 
-                                    Margin="40 0 0 10" FontSize="12"  VerticalAlignment="Center" TextWrapping="Wrap"
+                                            <TextBlock 
+                        Margin="40 0 0 10" FontSize="12"  VerticalAlignment="Center" TextWrapping="Wrap"
                                     Text="{x:Static properties:Localisation.Settings_Scrobbling_SongDurationChoice_Description}"/>
 
                                 <StackPanel Orientation="Horizontal" Margin="10 10 0 5">
                                     <TextBlock
                                         VerticalAlignment="Center" Padding="0 0 0 1" 
-                                        Text="{x:Static properties:Localisation.Settings_Scrobbling_ScrobbleTime}"/>
-                                    <TextBox 
-                                        x:Name="ScrobbleMaxTime" Width="60" Margin="10 0 7 2" Padding="7 5 7 5" TextWrapping="Wrap" HorizontalContentAlignment="Right"
+                                       Text="{x:Static properties:Localisation.Settings_Scrobbling_ScrobbleTime}"/>
+                                     <TextBox 
+                                       x:Name="ScrobbleMaxTime" Width="60" Margin="10 0 7 2" Padding="7 5 7 5" TextWrapping="Wrap" HorizontalContentAlignment="Right"
                                         MaxLines="1" MaxLength="5"
                                         Text="{Binding Source={x:Static properties:Settings.Default}, Path=ScrobbleMaxWait}"
                                         TextChanged="ScrobbleMaxTime_TextChanged"/>
                                     <TextBlock
                                         VerticalAlignment="Center" Padding="0 0 0 1" 
-                                        Text="{x:Static properties:Localisation.Settings_TimeUnitSeconds}"/>
+                                       Text="{x:Static properties:Localisation.Settings_TimeUnitSeconds}"/>
                                 </StackPanel>
-                                <TextBlock 
-                                    Margin="10 0 0 10" FontSize="12"  VerticalAlignment="Center" TextWrapping="Wrap"
+                                 <TextBlock 
+                                  Margin="10 0 0 10" FontSize="12"  VerticalAlignment="Center" TextWrapping="Wrap"
                                     Text="{x:Static properties:Localisation.Settings_Scrobbling_ScrobbleTime_Description}"/>
 
                                 <!-- Scrobbling settings: Last.FM -->
@@ -275,49 +269,47 @@
                                                 FontSize="16" FontWeight="SemiBold"
                                                 Text="{x:Static properties:Localisation.Settings_Scrobbling_LastFM_SectionTitle}"/>
                                             <StackPanel HorizontalAlignment="Right">
-                                            <ui:ToggleSwitch 
-                                                x:Name="CheckBox_LastfmEnable" Margin="0 2 0 10"
+                                              <ui:ToggleSwitch 
+                                             x:Name="CheckBox_LastfmEnable" Margin="0 2 0 10"
                                                 IsChecked="{Binding Source={x:Static properties:Settings.Default}, Path=LastfmEnable, Mode=TwoWay}"
                                                 Click="CheckBox_LastfmEnable_Click"/>
                                             </StackPanel>
                                         </DockPanel>
-                                        <TextBlock 
-                                            VerticalAlignment="Center"
+                                           <TextBlock 
+                                        VerticalAlignment="Center"
                                             Text="{x:Static properties:Localisation.Settings_Scrobbling_LastFM_ApiKey}"/>
-                                        <TextBox 
-                                            x:Name="LastfmAPIKey" Margin="0 7 0 10" TextWrapping="Wrap" FontFamily="Cascadia Mono"
-                                            IsEnabled="{Binding IsChecked, ElementName=CheckBox_LastfmEnable}" 
-                                            Text="{Binding Source={x:Static properties:Settings.Default}, Path=Default.LastfmAPIKey}"/>
+                                            <TextBox 
+                                       x:Name="LastfmAPIKey" Margin="0 7 0 10" TextWrapping="Wrap" FontFamily="Cascadia Mono"
+                                                 IsEnabled="{Binding IsChecked, ElementName=CheckBox_LastfmEnable}" 
+                                      Text="{Binding Source={x:Static properties:Settings.Default}, Path=Default.LastfmAPIKey}"/>
 
                                         <TextBlock
-                                            VerticalAlignment="Center" 
-                                            Text="{x:Static properties:Localisation.Settings_Scrobbling_LastFM_ApiSecret}"/>
                                         <TextBox 
-                                            x:Name="LastfmSecret" Margin="0 7 0 10" TextWrapping="Wrap" FontFamily="Cascadia Mono"
-                                            IsEnabled="{Binding IsChecked, ElementName=CheckBox_LastfmEnable}" 
-                                            Text="{Binding Source={x:Static properties:Settings.Default}, Path=Default.LastfmSecret}"/>
+                                           x:Name="LastfmSecret" Margin="0 7 0 10" TextWrapping="Wrap" FontFamily="Cascadia Mono"
+                                             IsEnabled="{Binding IsChecked, ElementName=CheckBox_LastfmEnable}" 
+                                          Text="{Binding Source={x:Static properties:Settings.Default}, Path=Default.LastfmSecret}"/>
 
-                                        <TextBlock 
+                                          <TextBlock 
                                             VerticalAlignment="Center" 
-                                            Text="{x:Static properties:Localisation.Settings_Scrobbling_LastFM_Username}"/>
-                                        <TextBox 
-                                            x:Name="LastfmUsername" Margin="0 7 0 10" TextWrapping="Wrap"
-                                            IsEnabled="{Binding IsChecked, ElementName=CheckBox_LastfmEnable}" 
-                                            Text="{Binding Source={x:Static properties:Settings.Default}, Path=Default.LastfmUsername}"/>
+                                        Text="{x:Static properties:Localisation.Settings_Scrobbling_LastFM_Username}"/>
+                                            <TextBox 
+                                       x:Name="LastfmUsername" Margin="0 7 0 10" TextWrapping="Wrap"
+                                                 IsEnabled="{Binding IsChecked, ElementName=CheckBox_LastfmEnable}" 
+                                      Text="{Binding Source={x:Static properties:Settings.Default}, Path=Default.LastfmUsername}"/>
 
                                         <TextBlock
                                             VerticalAlignment="Center"
                                             Text="{x:Static properties:Localisation.Settings_Scrobbling_LastFM_Password}"/>
-                                        <PasswordBox 
-                                            x:Name="LastfmPassword"  Margin="0 7 0 10" VerticalAlignment="Center"
+                                              <PasswordBox 
+                                     x:Name="LastfmPassword"  Margin="0 7 0 10" VerticalAlignment="Center"
                                             PasswordChar="●"
                                             IsEnabled="{Binding IsChecked, ElementName=CheckBox_LastfmEnable}"/>
 
-                                        <Button 
+                                               <Button 
                                             x:Name="SaveLastFMCreds" Margin="0 7 0 0" VerticalAlignment="Center" HorizontalAlignment="Right" 
-                                            IsEnabled="{Binding IsChecked, ElementName=CheckBox_LastfmEnable}"
-                                            Content="{x:Static properties:Localisation.Settings_Scrobbling_LastFM_SaveCredentials}" 
-                                            Click="SaveLastFMCreds_Click" />
+                                   IsEnabled="{Binding IsChecked, ElementName=CheckBox_LastfmEnable}"
+                                                     Content="{x:Static properties:Localisation.Settings_Scrobbling_LastFM_SaveCredentials}" 
+                                  Click="SaveLastFMCreds_Click" />
                                     </StackPanel>
                                 </ui:Card>
 
@@ -329,21 +321,20 @@
                                                 FontSize="16" FontWeight="SemiBold"
                                                 Text="{x:Static properties:Localisation.Settings_Scrobbling_ListenBrainz_SectionTitle}"/>
                                             <StackPanel HorizontalAlignment="Right">
-                                                <ui:ToggleSwitch 
-                                                    x:Name="CheckBox_ListenBrainzEnable" VerticalAlignment="Center" Margin="0 2 0 10"
+                                                          <ui:ToggleSwitch 
+                                          x:Name="CheckBox_ListenBrainzEnable" VerticalAlignment="Center" Margin="0 2 0 10"
                                                     IsChecked="{Binding Source={x:Static properties:Settings.Default}, Path=ListenBrainzEnable, Mode=TwoWay}"
                                                     Click="CheckBox_ListenBrainzEnable_Click"/>
                                             </StackPanel>
                                         </DockPanel>
                                         <TextBlock 
-                                            VerticalAlignment="Center"
+                                           VerticalAlignment="Center"
                                             Text="{x:Static properties:Localisation.Settings_Scrobbling_ListenBrainz_UserToken}"/>
-                                        <TextBox 
-                                            x:Name="ListenBrainzUserToken" Margin="0 7 0 10" FontFamily="Cascadia Mono"
-                                            IsEnabled="{Binding IsChecked, ElementName=CheckBox_ListenBrainzEnable}" 
+                                         <TextBox 
+                                          x:Name="ListenBrainzUserToken" Margin="0 7 0 10" FontFamily="Cascadia Mono"
+                                              IsEnabled="{Binding IsChecked, ElementName=CheckBox_ListenBrainzEnable}" 
                                             Text="{Binding Source={x:Static properties:Settings.Default}, Path=Default.ListenBrainzUserToken, Mode=TwoWay}" 
                                             TextWrapping="Wrap"/>               
-
                                         <Button x:Name="SaveListenBrainzCreds" Margin="0 7 0 0" VerticalAlignment="Center" HorizontalAlignment="Right" 
                                             IsEnabled="{Binding IsChecked, ElementName=CheckBox_ListenBrainzEnable}" 
                                             Content="{x:Static properties:Localisation.Settings_Scrobbling_LastFM_SaveCredentials}"

--- a/AMWin-RichPresence/SettingsWindow.xaml.cs
+++ b/AMWin-RichPresence/SettingsWindow.xaml.cs
@@ -82,6 +82,8 @@ namespace AMWin_RichPresence {
                 "tr" => ComboBoxItem_LanguageTurkish,
                 "ko" => ComboBoxItem_LanguageKorean,
                 "ja" => ComboBoxItem_LanguageJapanese,
+                "ru" => ComboBoxItem_LanguageRussian,
+                "es" => ComboBoxItem_LanguageSpanish,
                 _ => ComboBoxItem_LanguageSystem
             };
 

--- a/README-ES.md
+++ b/README-ES.md
@@ -1,0 +1,58 @@
+# AMWin-RP 
+![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/downloads-pre/PKBeam/AMWin-RP/total) ![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/downloads-pre/PKBeam/AMWin-RP/latest/total) &nbsp; ([English](README.md) | [한국어](README-KO.md) | [日本語](README-JA.md) | [Russian](README-RU.md))
+
+Un cliente de Discord Rich Presence para la app nativa de Apple Music en Windows.
+Además incluye scrobbling para Last.FM y ListenBrainz.
+
+<image width=450 src="https://github.com/user-attachments/assets/7a8e738a-d7af-4a67-9cf4-f4cf9c3c31d1" />
+&nbsp; &nbsp; 
+<image src=https://github.com/user-attachments/assets/f5464285-77de-4f98-ac8c-38dca5991c7f width=300 />
+
+## Instalación
+AMWin-RP requiere de Windows 11 24H2 o posterior.
+
+Las builds se pueden encontrar en [here](https://github.com/PKBeam/AMWin-RP/releases).  
+
+### ¿Qué versión debo usar?
+Elije x64 o ARM64 en función del procesador de tu PC.
+Después hay dos archivos entre los que elegir: el normal y el marcado como `NoRuntime`.
+
+En caso de duda, usa el *"release"* sin marcar (el que no contiene `NoRuntime`).
+Esta versión funciona universalmente, pero es de mayor tamaño debido a que tiene empaquetados los componentes de .NET necesarios para ejecutar la app.
+
+La versión `NoRuntime` tiene un tamaño notablemente más reducido, pero requiere tener instalado [.NET 10 desktop runtime](https://dotnet.microsoft.com/en-us/download/dotnet/10.0).
+Si no tienes el *runtime* instalado, el programa te notificará que lo hagas cuando se abra.
+
+## Uso
+Necesitas la versión de Apple Music de la [Microsoft store](https://apps.microsoft.com/detail/9PFHDD62MXS1) para poder usar AMWin-RP.
+
+- Ejecuta el .exe para iniciar la app.
+- AMWin-RP se ejecuta en segundo plano, minimizado en la bandeja del sistema.
+- Hacer doble clic en el icono de la bandeja abrirá la ventana de ajustes.
+  - Aquí podrás configurar las distintas opciones como ejecutar al iniciar el equipo, scrobbling y detección de canciones.
+- La aplicación puede cerrarse con clic derecho sobre el icono de la bandeja y seleccionando "Salir".
+- Por defecto, la app de Apple Music debe estar abierta y reproduciendo música (no pausada) para que se muestre el Rich Presence.
+
+**Nota**: Si haces uso de escritorios virtuales, AMWin-RP y Apple Music deberán estar en el mismo escritorio.
+Esta es una limitación técnica de la libresría UI Automation usada para extraer datos del cliente de Apple Music.
+
+## Scrobbling
+La implementación del scrobbler no admite los Scrobbles sin conexión, lo que implica que cualquier canción escuchada sin estar conectado a internét no será registrada.
+
+### Last.FM
+Necesitarás tu propia Clave API y API Secret de Last.FM.
+Para generar una, entra en https://www.last.fm/api y selecciona "Get an API Account".
+Introdúcelas en el menú de ajustes con tu nombre de usuario de Last.FM y tu contraseña.
+
+La contraseña de Last.FM se amacena en el [Administrador de credenciales de Windows](https://support.microsoft.com/es-es/windows/administrador-de-credenciales-en-windows-1b5c916a-6a16-889f-8581-fc16e8165ac0) bajo tu cuenta local de Windows. 
+
+### ListenBrainz 
+Puedes scrobblear en ListenBrainz añadiendo tu token de usuario en ajustes.
+
+## Reportar Errores
+Antes de crear un nuevo issue, asegúrate de que el problema no esté incluído en un issue ya existente.
+Si estás reportando un problema, por favor adjunta cualquier archivo `.log.` de relevancia (ubicados en `%localappdata%\AMWin-RichPresence`). 
+
+Antes de publicar, comprueba lo siguiente:
+- El problema no ha sido cubierto en ningún issue ya sea abierto o cerrado.
+- Tienes activado mostrar RP en Discord (Ajustes > Ajustes de Actividad > Privacidad de la actividad > Compartir mi Actividad).

--- a/README-JA.md
+++ b/README-JA.md
@@ -1,5 +1,5 @@
 # AMWin-RP 
-![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/downloads-pre/PKBeam/AMWin-RP/total) ![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/downloads-pre/PKBeam/AMWin-RP/latest/total) &nbsp; ([English](README.md) | [한국어](README-KO.md))
+![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/downloads-pre/PKBeam/AMWin-RP/total) ![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/downloads-pre/PKBeam/AMWin-RP/latest/total) &nbsp; ([English](README.md) | [한국어](README-KO.md) | [Russian](README-RU.md) | [Español](README-ES.md))
 
 Apple MusicのネイティブWindowsアプリ向けのDiscord Rich Presenceクライアントです。
 Last.FMおよびListenBrainzでのスクロブル（再生履歴の保存）もサポートしています。

--- a/README-KO.md
+++ b/README-KO.md
@@ -1,5 +1,5 @@
 # AMWin-RP
-![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/downloads-pre/PKBeam/AMWin-RP/total) ![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/downloads-pre/PKBeam/AMWin-RP/latest/total) &nbsp; ([English](README.md) | [日本語](README-JA.md))
+![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/downloads-pre/PKBeam/AMWin-RP/total) ![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/downloads-pre/PKBeam/AMWin-RP/latest/total) &nbsp; ([English](README.md) | [日本語](README-JA.md) | [Russian](README-RU.md) | [Español](README-ES.md))
 
 Apple Music 네이티브 Windows 앱용 Discord Rich Presence 클라이언트입니다.  
 Last.FM 및 ListenBrainz 스크로블링도 지원합니다.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # AMWin-RP 
-![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/downloads-pre/PKBeam/AMWin-RP/total) ![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/downloads-pre/PKBeam/AMWin-RP/latest/total) &nbsp; ([한국어](README-KO.md) | [日本語](README-JA.md))
+![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/downloads-pre/PKBeam/AMWin-RP/total) ![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/downloads-pre/PKBeam/AMWin-RP/latest/total) &nbsp; ([한국어](README-KO.md) | [日本語](README-JA.md) | [Russian](README-RU.md) | [Español](README-ES.md))
 
 A Discord Rich Presence client for Apple Music's native Windows app.  
 Also includes scrobbling for Last.FM and ListenBrainz.


### PR DESCRIPTION
Added Spanish localisation, taking into account the ongoing Russian localisation PR.

I've kept the language list order as-is for now to make a potential future merge easier. As a minor suggestion, it might be worth ordering them with Western languages first (English, Spanish, Russian, Turkish) and Eastern languages after (Japanese, Korean), but happy to defer to whatever convention the project prefers.

***

<img width="858" height="925" alt="スクリーンショット 2026-03-25 221452" src="https://github.com/user-attachments/assets/9bc45b60-9649-487e-8b3e-71ab8647808d" />

***

<img width="858" height="1036" alt="スクリーンショット 2026-03-25 221512" src="https://github.com/user-attachments/assets/868d38ef-6f52-4863-914a-70fad687875d" />

***
| System tray | Discord Rich Presence |
| :----: | :-----: |
| ![Screenshot_1](https://github.com/user-attachments/assets/750c0c8f-44ec-4875-a4a2-986c31f4e68a) | ![amwinrpES](https://github.com/user-attachments/assets/b25f314b-ebf6-4c03-8316-25e6081a5237) |

