### PR TITLE
#248 #249  Fix and Localisation

### DIFF
--- a/AMWin-RichPresence/Properties/Localisation.es.resx
+++ b/AMWin-RichPresence/Properties/Localisation.es.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+﻿﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!--
     Microsoft ResX Schema
@@ -137,6 +137,9 @@
   </data>
   <data name="Settings_Discord_ShowAlbumArt" xml:space="preserve">
     <value>Mostrar portada del álbum</value>
+  </data>
+  <data name="Settings_Discord_ShowAlbumTitle" xml:space="preserve">
+    <value>Mostrar título del álbum</value>
   </data>
   <data name="Settings_Discord_ShowWhenPaused" xml:space="preserve">
     <value>Mostrar cuando la música está pausada</value>
@@ -285,6 +288,9 @@
   <data name="Settings_Discord_ShowAppleMusicIcon_Description" xml:space="preserve">
     <value>Muestra el icono de Apple Music junto a la portada del álbum en el Rich Presence display.</value>
   </data>
+  <data name="Settings_Discord_ShowAlbumTitle_Description" xml:space="preserve">
+    <value>Muestra el título del álbum debajo de la canción y el artista en el Rich Presence display.</value>
+  </data>
   <data name="Settings_Discord_Lyrics_ShowDuringBreak_Description" xml:space="preserve">
     <value>Durante los silencios en la música, seguir mostrando las últimas letras cantadas.</value>
   </data>
@@ -325,7 +331,7 @@
     <value>Reinicia la app después de cambiar el idioma para aplicar correctamente los cambios.</value>
   </data>
   <data name="Settings_General_Language_System" xml:space="preserve">
-    <value>Por defecto del sistema (Por defecto del sistema)</value>
+    <value>Por defecto del sistema (System default)</value>
   </data>
   <data name="Settings_General_Language_English" xml:space="preserve">
     <value>Inglés (English)</value>

--- a/AMWin-RichPresence/Properties/Localisation.ru.resx
+++ b/AMWin-RichPresence/Properties/Localisation.ru.resx
@@ -138,6 +138,9 @@
   <data name="Settings_Discord_ShowAlbumArt" xml:space="preserve">
     <value>Показывать обложку альбома</value>
   </data>
+  <data name="Settings_Discord_ShowAlbumTitle" xml:space="preserve">
+    <value>[TRANSLATE]</value>
+  </data>
   <data name="Settings_Discord_ShowWhenPaused" xml:space="preserve">
     <value>Показывать при паузе</value>
   </data>
@@ -285,6 +288,9 @@
   <data name="Settings_Discord_ShowAppleMusicIcon_Description" xml:space="preserve">
     <value>Показывает значок Apple Music рядом с обложкой альбома в Rich Presence.</value>
   </data>
+  <data name="Settings_Discord_AlbumTitle_Description" xml:space="preserve">
+    <value>[TRANSLATE]</value>
+  </data>
   <data name="Settings_Discord_Lyrics_ShowDuringBreak_Description" xml:space="preserve">
     <value>Во время пауз в музыке продолжать показывать последнюю строку текста.</value>
   </data>
@@ -341,6 +347,9 @@
   </data>
   <data name="Settings_General_Language_Russian" xml:space="preserve">
     <value>Русский (Русский)</value>
+  </data>
+  <data name="Settings_General_Language_Spanish" xml:space="preserve">
+    <value>Испанский (Español)</value>
   </data>
   <data name="Message_RestartRequired_Title" xml:space="preserve">
     <value>Требуется перезапуск</value>

--- a/AMWin-RichPresence/SettingsWindow.xaml
+++ b/AMWin-RichPresence/SettingsWindow.xaml
@@ -1,4 +1,4 @@
-﻿<ui:FluentWindow
+﻿﻿<ui:FluentWindow
     x:Class="AMWin_RichPresence.SettingsWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -45,7 +45,7 @@
                         x:Name="NavItemDiscord"
                         Content="{x:Static properties:Localisation.Settings_Discord_SectionTitleShort}"
                         Icon="{ui:SymbolIcon XboxController48}" 
-                       Click="NavItemDiscord_Click"/>
+                        Click="NavItemDiscord_Click"/>
                     <ui:NavigationViewItem
                         x:Name="NavItemScrobbling"
                         Content="{x:Static properties:Localisation.Settings_Scrobbling_SectionTitle}"
@@ -66,22 +66,22 @@
                                     x:Name="CheckBox_RunOnStartup" 
                                     IsChecked="{Binding Source={x:Static properties:Settings.Default}, Path=RunOnStartup, Mode=TwoWay}" 
                                     Click="CheckBox_RunOnStartup_Click" 
-                                 Content="{x:Static properties:Localisation.Settings_General_RunOnWindowsStartup}"/>
+                                    Content="{x:Static properties:Localisation.Settings_General_RunOnWindowsStartup}"/>
 
                                 <CheckBox
-                                       x:Name="CheckBox_CheckForUpdatesOnStartup" 
+                                    x:Name="CheckBox_CheckForUpdatesOnStartup" 
                                     IsChecked="{Binding Source={x:Static properties:Settings.Default}, Path=CheckForUpdatesOnStartup, Mode=TwoWay}" 
                                     Click="CheckBox_CheckForUpdatesOnStartup_Click" 
-                                 Content="{x:Static properties:Localisation.Settings_General_UpdateOnStartup}"/>
+                                    Content="{x:Static properties:Localisation.Settings_General_UpdateOnStartup}"/>
 
                                 <CheckBox
                                     x:Name="CheckBox_ClassicalComposerAsArtist" 
                                     IsChecked="{Binding Source={x:Static properties:Settings.Default}, Path=ClassicalComposerAsArtist, Mode=TwoWay}" 
                                     Click="CheckBox_ClassicalComposerAsArtist_Click"
                                     Content="{x:Static properties:Localisation.Settings_General_ComposerAsArtist}"/>
-
+                                
                                 <TextBlock 
-   Margin="40 0 0 10" FontSize="12"  VerticalAlignment="Center" TextWrapping="Wrap"
+                                    Margin="40 0 0 10" FontSize="12"  VerticalAlignment="Center" TextWrapping="Wrap"
                                     Text="{x:Static properties:Localisation.Settings_General_ComposerAsArtist_Description}"/>
 
                                 <StackPanel Orientation="Horizontal" Margin="10 10 0 2">
@@ -100,6 +100,7 @@
                                         <ComboBoxItem x:Name="ComboBoxItem_LanguageKorean" Tag="ko" Content="Korean (한국어)"/>
                                         <ComboBoxItem x:Name="ComboBoxItem_LanguageJapanese" Tag="ja" Content="Japanese (日本語)"/>
                                         <ComboBoxItem x:Name="ComboBoxItem_LanguageRussian" Tag="ru" Content="Russian (Русский)"/>
+                                        <ComboBoxItem x:Name="ComboBoxItem_LanguageSpanish" Tag="es" Content="Spanish (Español)"/>
                                     </ComboBox>
                                 </StackPanel>
                                 <TextBlock
@@ -129,15 +130,15 @@
                                 <TextBlock
                                     x:Name="SectionTitleDiscord"
                                     FontSize="18" FontWeight="Bold" Padding="0 15 0 5" Margin="0 10 0 7" VerticalAlignment="Top" 
-                                   Text="{x:Static properties:Localisation.Settings_Discord_SectionTitle}"/>
+                                    Text="{x:Static properties:Localisation.Settings_Discord_SectionTitle}"/>
 
-                                 <CheckBox 
+                                <CheckBox 
                                     x:Name="CheckBox_EnableDiscordRP" 
                                     IsChecked="{Binding Source={x:Static properties:Settings.Default}, Path=EnableDiscordRP, Mode=TwoWay}" 
                                     Click="CheckBox_EnableDiscordRP_Click" 
-                               Content="{x:Static properties:Localisation.Settings_Discord_EnableRP}"/>
+                                    Content="{x:Static properties:Localisation.Settings_Discord_EnableRP}"/>
 
-                                     <CheckBox 
+                                <CheckBox 
                                     x:Name="CheckBox_EnableRPCoverImages" 
                                     IsEnabled="{Binding IsChecked, ElementName=CheckBox_EnableDiscordRP}" 
                                     IsChecked="{Binding Source={x:Static properties:Settings.Default}, Path=EnableRPCoverImages, Mode=TwoWay}" 
@@ -152,17 +153,18 @@
                                     Content="{x:Static properties:Localisation.Settings_Discord_ShowAlbumTitle}"/>
 
                                 <CheckBox
-                                              x:Name="CheckBox_ShowRPWhenMusicPaused" 
+                                    x:Name="CheckBox_ShowRPWhenMusicPaused" 
                                     IsEnabled="{Binding IsChecked, ElementName=CheckBox_EnableDiscordRP}" 
                                     IsChecked="{Binding Source={x:Static properties:Settings.Default}, Path=ShowRPWhenMusicPaused, Mode=TwoWay}" 
                                     Click="CheckBox_ShowRPWhenMusicPaused_Click" 
-                      Content="{x:Static properties:Localisation.Settings_Discord_ShowWhenPaused}"/>
+                                    Content="{x:Static properties:Localisation.Settings_Discord_ShowWhenPaused}"/>
 
-                                              <CheckBox 
+                                <CheckBox 
                                     x:Name="CheckBox_ShowAppleMusicIcon" 
                                     IsEnabled="{Binding IsChecked, ElementName=CheckBox_EnableDiscordRP}" 
                                     IsChecked="{Binding Source={x:Static properties:Settings.Default}, Path=ShowAppleMusicIcon, Mode=TwoWay}" 
                                     Click="CheckBox_ShowAppleMusicIcon_Click" 
+                                    Content="{x:Static properties:Localisation.Settings_Discord_ShowAppleMusicIcon}"/>
                                 <TextBlock 
                                     Margin="40 0 0 10" FontSize="12"  VerticalAlignment="Center" TextWrapping="Wrap"
                                     Text="{x:Static properties:Localisation.Settings_Discord_ShowAppleMusicIcon_Description}"/>
@@ -170,13 +172,13 @@
                                 <StackPanel Orientation="Horizontal" Margin="10 7 0 7">
                                     <TextBlock 
                                         VerticalAlignment="Center" 
-                                      Margin="0 0 10 2"
+                                        Margin="0 0 10 2"
                                         Text="{x:Static properties:Localisation.Settings_Discord_UserStatusDisplay}"/>
-                                      <ComboBox 
+                                    <ComboBox 
                                         x:Name="ComboBox_RPDisplayChoice" 
                                         IsEnabled="{Binding IsChecked, ElementName=CheckBox_EnableDiscordRP}" 
                                         SelectedIndex="{Binding Source={x:Static properties:Settings.Default}, Path=RPDisplayChoice, Mode=TwoWay}" 
-                                  SelectionChanged="ComboBox_RPDisplayChoice_SelectionChanged">
+                                        SelectionChanged="ComboBox_RPDisplayChoice_SelectionChanged">
                                         <!-- The order of these items matters! (check the enum in AppleMusicDiscordClient.cs) -->
                                         <ComboBoxItem Content="{x:Static properties:Localisation.Settings_Discord_UserStatusDisplay_Artist}"/>
                                         <ComboBoxItem Content="{x:Static properties:Localisation.Settings_Discord_UserStatusDisplay_AppleMusic}"/>
@@ -188,25 +190,25 @@
                                 <ui:Card Margin="0 15 0 5">
                                     <StackPanel>
                                         <DockPanel Margin="0 0 0 7">
-                                                  <TextBlock 
+                                            <TextBlock 
                                                 FontSize="16" FontWeight="SemiBold" VerticalAlignment="Top" 
-                                        IsEnabled="{Binding IsChecked, ElementName=CheckBox_EnableDiscordRP}"
+                                                IsEnabled="{Binding IsChecked, ElementName=CheckBox_EnableDiscordRP}"
                                                 Text="{x:Static properties:Localisation.Settings_Discord_Lyrics_SectionTitle}"/>
                                             <StackPanel HorizontalAlignment="Right">
-                                                        <ui:ToggleSwitch 
+                                                <ui:ToggleSwitch 
                                                     x:Name="CheckBox_EnableSyncLyrics" 
                                                     IsChecked="{Binding Source={x:Static properties:Settings.Default}, Path=EnableSyncLyrics, Mode=TwoWay}" 
-                                         Click="CheckBox_EnableSyncLyrics_Click"/>
+                                                    Click="CheckBox_EnableSyncLyrics_Click"/>
                                             </StackPanel>
                                         </DockPanel>
 
-                                                   <TextBlock 
-                                Margin="0 0 0 15" FontSize="12"  VerticalAlignment="Center" TextWrapping="Wrap"
+                                        <TextBlock 
+                                            Margin="0 0 0 15" FontSize="12"  VerticalAlignment="Center" TextWrapping="Wrap"
                                             Text="{x:Static properties:Localisation.Settings_Discord_Lyrics_EnableLyrics}"/>
-
-                                                   
+                                        
                                         <CheckBox 
                                             x:Name="CheckBox_ExtendLyricsLine" 
+                                            IsEnabled="{Binding IsChecked, ElementName=CheckBox_EnableSyncLyrics}"
                                             IsChecked="{Binding Source={x:Static properties:Settings.Default}, Path=ExtendLyricsLine, Mode=TwoWay}" 
                                             Click="CheckBox_ExtendLyricsLine_Click" 
                                             Content="{x:Static properties:Localisation.Settings_Discord_Lyrics_ShowDuringBreak}"/>
@@ -223,55 +225,55 @@
                                                 x:Name="Button_DeleteLyricCache"
                                                 Content="{x:Static properties:Localisation.Settings_Discord_Lyrics_ClearCache}" 
                                                 Click="Button_DeleteLyricCache_Click"/>
-                                        </StackPanel>
+                                        </StackPanel>   
                                     </StackPanel>
                                 </ui:Card>
-
+                                
                                 <!-- Scrobbling settings -->
                                 <TextBlock 
-                                   x:Name="SectionTitleScrobbling"
-                                     Padding="0 15 0 5" Margin="0 20 0 7" FontWeight="Bold" FontSize="18" 
-                                  Text="{x:Static properties:Localisation.Settings_Scrobbling_SectionTitle}"/>
+                                    x:Name="SectionTitleScrobbling"
+                                    Padding="0 15 0 5" Margin="0 20 0 7" FontWeight="Bold" FontSize="18" 
+                                    Text="{x:Static properties:Localisation.Settings_Scrobbling_SectionTitle}"/>
 
                                 <CheckBox 
                                     x:Name="CheckBox_LastfmCleanAlbumName"
-                                      IsChecked="{Binding Source={x:Static properties:Settings.Default}, Path=LastfmCleanAlbumName, Mode=TwoWay}" 
+                                    IsChecked="{Binding Source={x:Static properties:Settings.Default}, Path=LastfmCleanAlbumName, Mode=TwoWay}" 
                                     Click="CheckBox_LastfmCleanAlbumName_Click" 
-                                Content="{x:Static properties:Localisation.Settings_Scrobbling_CleanAlbumName}"/>
-                                    <TextBlock 
-                               Margin="40 0 0 10" FontSize="12"  VerticalAlignment="Center" TextWrapping="Wrap"
+                                    Content="{x:Static properties:Localisation.Settings_Scrobbling_CleanAlbumName}"/>
+                                <TextBlock 
+                                    Margin="40 0 0 10" FontSize="12"  VerticalAlignment="Center" TextWrapping="Wrap"
                                     Text="{x:Static properties:Localisation.Settings_Scrobbling_CleanAlbumName_Description}"/>
 
-                                     <CheckBox 
+                                <CheckBox 
                                     x:Name="CheckBox_LastfmScrobblePrimary" Margin="0 2 0 0" 
                                     IsChecked="{Binding Source={x:Static properties:Settings.Default}, Path=LastfmScrobblePrimaryArtist, Mode=TwoWay}" 
                                     Click="CheckBox_LastfmScrobblePrimary_Click" 
-                           Content="{x:Static properties:Localisation.Settings_Scrobbling_ScrobblePrimaryArtist}"/>
+                                    Content="{x:Static properties:Localisation.Settings_Scrobbling_ScrobblePrimaryArtist}"/>
 
-                                         <CheckBox 
+                                <CheckBox 
                                     x:Name="CheckBox_ScrobblePreferAppleMusicWebDuration" 
                                     Margin="0 2 0 0" IsChecked="{Binding Source={x:Static properties:Settings.Default}, Path=ScrobblePreferAppleMusicWebDuration, Mode=TwoWay}" 
-                        Checked="CheckBox_ScrobblePreferAppleMusicWebDuration_Checked"
+                                    Checked="CheckBox_ScrobblePreferAppleMusicWebDuration_Checked"
                                     Content="{x:Static properties:Localisation.Settings_Scrobbling_SongDurationChoice}"/>
-                                            <TextBlock 
-                        Margin="40 0 0 10" FontSize="12"  VerticalAlignment="Center" TextWrapping="Wrap"
+                                <TextBlock 
+                                    Margin="40 0 0 10" FontSize="12"  VerticalAlignment="Center" TextWrapping="Wrap"
                                     Text="{x:Static properties:Localisation.Settings_Scrobbling_SongDurationChoice_Description}"/>
 
                                 <StackPanel Orientation="Horizontal" Margin="10 10 0 5">
                                     <TextBlock
                                         VerticalAlignment="Center" Padding="0 0 0 1" 
-                                       Text="{x:Static properties:Localisation.Settings_Scrobbling_ScrobbleTime}"/>
-                                     <TextBox 
-                                       x:Name="ScrobbleMaxTime" Width="60" Margin="10 0 7 2" Padding="7 5 7 5" TextWrapping="Wrap" HorizontalContentAlignment="Right"
+                                        Text="{x:Static properties:Localisation.Settings_Scrobbling_ScrobbleTime}"/>
+                                    <TextBox 
+                                        x:Name="ScrobbleMaxTime" Width="60" Margin="10 0 7 2" Padding="7 5 7 5" TextWrapping="Wrap" HorizontalContentAlignment="Right"
                                         MaxLines="1" MaxLength="5"
                                         Text="{Binding Source={x:Static properties:Settings.Default}, Path=ScrobbleMaxWait}"
                                         TextChanged="ScrobbleMaxTime_TextChanged"/>
                                     <TextBlock
                                         VerticalAlignment="Center" Padding="0 0 0 1" 
-                                       Text="{x:Static properties:Localisation.Settings_TimeUnitSeconds}"/>
+                                        Text="{x:Static properties:Localisation.Settings_TimeUnitSeconds}"/>
                                 </StackPanel>
-                                 <TextBlock 
-                                  Margin="10 0 0 10" FontSize="12"  VerticalAlignment="Center" TextWrapping="Wrap"
+                                <TextBlock 
+                                    Margin="10 0 0 10" FontSize="12"  VerticalAlignment="Center" TextWrapping="Wrap"
                                     Text="{x:Static properties:Localisation.Settings_Scrobbling_ScrobbleTime_Description}"/>
 
                                 <!-- Scrobbling settings: Last.FM -->
@@ -282,47 +284,49 @@
                                                 FontSize="16" FontWeight="SemiBold"
                                                 Text="{x:Static properties:Localisation.Settings_Scrobbling_LastFM_SectionTitle}"/>
                                             <StackPanel HorizontalAlignment="Right">
-                                                <ui:ToggleSwitch 
+                                            <ui:ToggleSwitch 
                                                 x:Name="CheckBox_LastfmEnable" Margin="0 2 0 10"
                                                 IsChecked="{Binding Source={x:Static properties:Settings.Default}, Path=LastfmEnable, Mode=TwoWay}"
                                                 Click="CheckBox_LastfmEnable_Click"/>
                                             </StackPanel>
                                         </DockPanel>
-                                           <TextBlock 
-                                        VerticalAlignment="Center"
+                                        <TextBlock 
+                                            VerticalAlignment="Center"
                                             Text="{x:Static properties:Localisation.Settings_Scrobbling_LastFM_ApiKey}"/>
-                                            <TextBox 
-                                       x:Name="LastfmAPIKey" Margin="0 7 0 10" TextWrapping="Wrap" FontFamily="Cascadia Mono"
-                                                 IsEnabled="{Binding IsChecked, ElementName=CheckBox_LastfmEnable}" 
-                                      Text="{Binding Source={x:Static properties:Settings.Default}, Path=Default.LastfmAPIKey}"/>
+                                        <TextBox 
+                                            x:Name="LastfmAPIKey" Margin="0 7 0 10" TextWrapping="Wrap" FontFamily="Cascadia Mono"
+                                            IsEnabled="{Binding IsChecked, ElementName=CheckBox_LastfmEnable}" 
+                                            Text="{Binding Source={x:Static properties:Settings.Default}, Path=Default.LastfmAPIKey}"/>
 
                                         <TextBlock
-                                        <TextBox 
-                                           x:Name="LastfmSecret" Margin="0 7 0 10" TextWrapping="Wrap" FontFamily="Cascadia Mono"
-                                             IsEnabled="{Binding IsChecked, ElementName=CheckBox_LastfmEnable}" 
-                                          Text="{Binding Source={x:Static properties:Settings.Default}, Path=Default.LastfmSecret}"/>
-
-                                          <TextBlock 
                                             VerticalAlignment="Center" 
-                                        Text="{x:Static properties:Localisation.Settings_Scrobbling_LastFM_Username}"/>
-                                            <TextBox 
-                                       x:Name="LastfmUsername" Margin="0 7 0 10" TextWrapping="Wrap"
-                                                 IsEnabled="{Binding IsChecked, ElementName=CheckBox_LastfmEnable}" 
-                                      Text="{Binding Source={x:Static properties:Settings.Default}, Path=Default.LastfmUsername}"/>
+                                            Text="{x:Static properties:Localisation.Settings_Scrobbling_LastFM_ApiSecret}"/>
+                                        <TextBox 
+                                            x:Name="LastfmSecret" Margin="0 7 0 10" TextWrapping="Wrap" FontFamily="Cascadia Mono"
+                                            IsEnabled="{Binding IsChecked, ElementName=CheckBox_LastfmEnable}" 
+                                            Text="{Binding Source={x:Static properties:Settings.Default}, Path=Default.LastfmSecret}"/>
+
+                                        <TextBlock 
+                                            VerticalAlignment="Center" 
+                                            Text="{x:Static properties:Localisation.Settings_Scrobbling_LastFM_Username}"/>
+                                        <TextBox 
+                                            x:Name="LastfmUsername" Margin="0 7 0 10" TextWrapping="Wrap"
+                                            IsEnabled="{Binding IsChecked, ElementName=CheckBox_LastfmEnable}" 
+                                            Text="{Binding Source={x:Static properties:Settings.Default}, Path=Default.LastfmUsername}"/>
 
                                         <TextBlock
                                             VerticalAlignment="Center"
                                             Text="{x:Static properties:Localisation.Settings_Scrobbling_LastFM_Password}"/>
-                                              <PasswordBox 
-                                     x:Name="LastfmPassword"  Margin="0 7 0 10" VerticalAlignment="Center"
+                                        <PasswordBox 
+                                            x:Name="LastfmPassword"  Margin="0 7 0 10" VerticalAlignment="Center"
                                             PasswordChar="●"
                                             IsEnabled="{Binding IsChecked, ElementName=CheckBox_LastfmEnable}"/>
 
-                                               <Button 
+                                        <Button 
                                             x:Name="SaveLastFMCreds" Margin="0 7 0 0" VerticalAlignment="Center" HorizontalAlignment="Right" 
-                                   IsEnabled="{Binding IsChecked, ElementName=CheckBox_LastfmEnable}"
-                                                     Content="{x:Static properties:Localisation.Settings_Scrobbling_LastFM_SaveCredentials}" 
-                                  Click="SaveLastFMCreds_Click" />
+                                            IsEnabled="{Binding IsChecked, ElementName=CheckBox_LastfmEnable}"
+                                            Content="{x:Static properties:Localisation.Settings_Scrobbling_LastFM_SaveCredentials}" 
+                                            Click="SaveLastFMCreds_Click" />
                                     </StackPanel>
                                 </ui:Card>
 
@@ -334,20 +338,20 @@
                                                 FontSize="16" FontWeight="SemiBold"
                                                 Text="{x:Static properties:Localisation.Settings_Scrobbling_ListenBrainz_SectionTitle}"/>
                                             <StackPanel HorizontalAlignment="Right">
-                                                          <ui:ToggleSwitch 
-                                          x:Name="CheckBox_ListenBrainzEnable" VerticalAlignment="Center" Margin="0 2 0 10"
+                                                <ui:ToggleSwitch 
+                                                    x:Name="CheckBox_ListenBrainzEnable" VerticalAlignment="Center" Margin="0 2 0 10"
                                                     IsChecked="{Binding Source={x:Static properties:Settings.Default}, Path=ListenBrainzEnable, Mode=TwoWay}"
                                                     Click="CheckBox_ListenBrainzEnable_Click"/>
                                             </StackPanel>
                                         </DockPanel>
                                         <TextBlock 
-                                           VerticalAlignment="Center"
+                                            VerticalAlignment="Center"
                                             Text="{x:Static properties:Localisation.Settings_Scrobbling_ListenBrainz_UserToken}"/>
-                                         <TextBox 
-                                          x:Name="ListenBrainzUserToken" Margin="0 7 0 10" FontFamily="Cascadia Mono"
-                                              IsEnabled="{Binding IsChecked, ElementName=CheckBox_ListenBrainzEnable}" 
+                                        <TextBox 
+                                            x:Name="ListenBrainzUserToken" Margin="0 7 0 10" FontFamily="Cascadia Mono"
+                                            IsEnabled="{Binding IsChecked, ElementName=CheckBox_ListenBrainzEnable}" 
                                             Text="{Binding Source={x:Static properties:Settings.Default}, Path=Default.ListenBrainzUserToken, Mode=TwoWay}" 
-                                            TextWrapping="Wrap"/>
+                                            TextWrapping="Wrap"/>               
 
                                         <Button x:Name="SaveListenBrainzCreds" Margin="0 7 0 0" VerticalAlignment="Center" HorizontalAlignment="Right" 
                                             IsEnabled="{Binding IsChecked, ElementName=CheckBox_ListenBrainzEnable}" 

--- a/AMWin-RichPresence/SettingsWindow.xaml.cs
+++ b/AMWin-RichPresence/SettingsWindow.xaml.cs
@@ -71,6 +71,7 @@ namespace AMWin_RichPresence {
             ComboBoxItem_LanguageKorean.Content = GetLocalisedString("Settings_General_Language_Korean", "Korean (한국어)");
             ComboBoxItem_LanguageJapanese.Content = GetLocalisedString("Settings_General_Language_Japanese", "Japanese (日本語)");
             ComboBoxItem_LanguageRussian.Content = GetLocalisedString("Settings_General_Language_Russian", "Russian (Русский)");
+            ComboBoxItem_LanguageSpanish.Content = GetLocalisedString("Settings_General_Language_Spanish", "Spanish (Español)");
 
             var selectedLanguage = App.NormalizeLanguageCode(Properties.Settings.Default.Language);
             if (!String.Equals(selectedLanguage, Properties.Settings.Default.Language, StringComparison.Ordinal)) {

--- a/README-RU.md
+++ b/README-RU.md
@@ -1,5 +1,5 @@
 # AMWin-RP
-![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/downloads-pre/PKBeam/AMWin-RP/total) ![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/downloads-pre/PKBeam/AMWin-RP/latest/total) &nbsp; ([English](README.md) | [Korean](README-KO.md) | [Japanese](README-JA.md))
+![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/downloads-pre/PKBeam/AMWin-RP/total) ![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/downloads-pre/PKBeam/AMWin-RP/latest/total) &nbsp; ([English](README.md) | [Korean](README-KO.md) | [Japanese](README-JA.md) | [Español](README-ES.md))
 
 Клиент Discord Rich Presence для нативного приложения Apple Music на Windows.  
 Также включает скробблинг в Last.FM и ListenBrainz.


### PR DESCRIPTION
Sorry, on the Spanish localisation #248 PR, I messed up the formatting of SettingsWindow.xaml and somehow broke it.

Restored the previous format and correct functionality.

Other changes:
- Updated localisation for the #249 PR feature.
- Added Spanish language options to the Russian localisation (README-RU.md and Localisation.ru.resx).
- Added Spanish language ComboBoxItem to SettingsWindow.xaml.cs.

Tested the release build, and everything works now.