### PR TITLE
Fix Last.FM NowPlaying race condition and bump version to 1.6.2

### DIFF
--- a/AMWin-RichPresence/AMWin-RichPresence.csproj
+++ b/AMWin-RichPresence/AMWin-RichPresence.csproj
@@ -8,7 +8,7 @@
     <UseWPF>true</UseWPF>
     <ApplicationIcon>Resources\AMWinRP.ico</ApplicationIcon>
     <AssemblyVersion>1.0</AssemblyVersion>
-    <FileVersion>1.6.1</FileVersion>
+    <FileVersion>1.6.2</FileVersion>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <SupportedOSPlatformVersion>10.0.26100.0</SupportedOSPlatformVersion>
     <ApplicationManifest>app.manifest</ApplicationManifest>

--- a/AMWin-RichPresence/App.xaml
+++ b/AMWin-RichPresence/App.xaml
@@ -1,4 +1,4 @@
-﻿<Application x:Class="AMWin_RichPresence.App"
+<Application x:Class="AMWin_RichPresence.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:AMWin_RichPresence"

--- a/AMWin-RichPresence/AppleMusicScrobbler.cs
+++ b/AMWin-RichPresence/AppleMusicScrobbler.cs
@@ -36,6 +36,7 @@ namespace AMWin_RichPresence {
         protected int elapsedSeconds;
         protected string? lastSongID;
         protected bool hasScrobbled;
+        protected bool nowPlayingSent;
         protected double lastSongProgress;
         protected Logger? logger;
         protected string serviceName;
@@ -71,7 +72,7 @@ namespace AMWin_RichPresence {
 
         public abstract Task<bool> UpdateCredsAsync(C credentials);
 
-        protected abstract Task UpdateNowPlaying(string artist, string album, string song);
+        protected abstract Task<bool> UpdateNowPlaying(string artist, string album, string song);
 
         protected abstract Task ScrobbleSong(string artist, string album, string song);
 
@@ -95,10 +96,8 @@ namespace AMWin_RichPresence {
                     elapsedSeconds = 0;
                     scrobbleInProgress = false;
                     hasScrobbled = false;
+                    nowPlayingSent = false;
                     logger?.Log($"[{serviceName} scrobbler] New Song: {lastSongID}");
-
-                    await UpdateNowPlaying(artist, album, info.SongName);
-                    logger?.Log($"[{serviceName} scrobbler] Updated now playing: {lastSongID}");
                 } else {
                     elapsedSeconds += Constants.RefreshPeriod;
 
@@ -121,6 +120,13 @@ namespace AMWin_RichPresence {
                     }
 
                     lastSongProgress = info.CurrentTime ?? 0.0;
+                }
+
+                if (!nowPlayingSent) {
+                    nowPlayingSent = await UpdateNowPlaying(artist, album, info.SongName);
+                    if (nowPlayingSent) {
+                        logger?.Log($"[{serviceName} scrobbler] Updated now playing: {lastSongID}");
+                    }
                 }
             } catch (Exception ex) {
                 logger?.Log($"[{serviceName} scrobbler] An error occurred while scrobbling: {ex}");
@@ -174,13 +180,14 @@ namespace AMWin_RichPresence {
             await lastFmScrobbler.ScrobbleAsync(scrobble);
         }
 
-        protected async override Task UpdateNowPlaying(string artist, string album, string song) {
+        protected async override Task<bool> UpdateNowPlaying(string artist, string album, string song) {
             if (trackApi == null || lastfmAuth?.Authenticated != true) {
-                return;
+                return false;
             }
 
             var scrobble = new Scrobble(artist, album, song, DateTime.UtcNow);
             await trackApi.UpdateNowPlayingAsync(scrobble);
+            return true;
         }
     }
 
@@ -223,12 +230,13 @@ namespace AMWin_RichPresence {
             await listenBrainzClient.SubmitSingleListenAsync(song, artist, album);
         }
 
-        protected async override Task UpdateNowPlaying(string artist, string album, string song) {
+        protected async override Task<bool> UpdateNowPlaying(string artist, string album, string song) {
             if (string.IsNullOrEmpty(listenBrainzClient?.UserToken)) {
-                return;
+                return false;
             }
 
             await listenBrainzClient.SetNowPlayingAsync(song, artist, album);
+            return true;
         }
     }
 }

--- a/AMWin-RichPresence/Properties/Localisation.es.resx
+++ b/AMWin-RichPresence/Properties/Localisation.es.resx
@@ -1,4 +1,4 @@
-﻿﻿<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!--
     Microsoft ResX Schema

--- a/AMWin-RichPresence/Properties/Localisation.ja.resx
+++ b/AMWin-RichPresence/Properties/Localisation.ja.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!--
     Microsoft ResX Schema

--- a/AMWin-RichPresence/Properties/Localisation.ko.resx
+++ b/AMWin-RichPresence/Properties/Localisation.ko.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!--
     Microsoft ResX Schema

--- a/AMWin-RichPresence/Properties/Localisation.resx
+++ b/AMWin-RichPresence/Properties/Localisation.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!--
     Microsoft ResX Schema

--- a/AMWin-RichPresence/Properties/Localisation.tr.resx
+++ b/AMWin-RichPresence/Properties/Localisation.tr.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!--
     Microsoft ResX Schema

--- a/AMWin-RichPresence/Properties/Resources.resx
+++ b/AMWin-RichPresence/Properties/Resources.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 

--- a/AMWin-RichPresence/Properties/Settings.settings
+++ b/AMWin-RichPresence/Properties/Settings.settings
@@ -1,4 +1,4 @@
-﻿<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='utf-8'?>
 <SettingsFile xmlns="http://schemas.microsoft.com/VisualStudio/2004/01/settings" CurrentProfile="(Default)" GeneratedClassNamespace="AMWin_RichPresence.Properties" GeneratedClassName="Settings">
   <Profiles />
   <Settings>

--- a/AMWin-RichPresence/SettingsWindow.xaml
+++ b/AMWin-RichPresence/SettingsWindow.xaml
@@ -1,4 +1,4 @@
-﻿﻿<ui:FluentWindow
+﻿<ui:FluentWindow
     x:Class="AMWin_RichPresence.SettingsWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/AMWin-RichPresence/TaskbarIconResources.xaml
+++ b/AMWin-RichPresence/TaskbarIconResources.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:tb="http://www.hardcodet.net/taskbar"
                     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"


### PR DESCRIPTION
- Bug: NowPlaying was never sent for the track playing when the app launched, due to a race condition — init() is
  fire-and-forget so trackApi was null on the first tick, but lastSongID was already set so no retry ever happened
- Fix: Added nowPlayingSent flag per song; retries UpdateNowPlaying each tick until it succeeds
- Also: Stripped UTF-8 BOM from XAML/resx/settings files to fix dotnet build under .NET 10