### PR TITLE
fix: handle update check failures and settings bindings

### DIFF
--- a/AMWin-RichPresence/App.xaml.cs
+++ b/AMWin-RichPresence/App.xaml.cs
@@ -107,12 +107,7 @@ namespace AMWin_RichPresence {
 
             // check for updates
             if (AMWin_RichPresence.Properties.Settings.Default.CheckForUpdatesOnStartup) {
-                try {
-                    CheckForUpdates();
-                    logger?.Log("No AMWin-RP updates available.");
-                } catch (Exception e) {
-                    logger?.Log($"Could not check for AMWin-RP updates: {e.Message}");
-                }
+                _ = CheckForUpdates();
             }
 
             // start Discord RPC
@@ -206,39 +201,49 @@ namespace AMWin_RichPresence {
             amScraper.composerAsArtist = composerAsArtist;
         }
 
-        internal async void CheckForUpdates() {
-            static int StringVerToInt(string v) {
-                var verStr = v[1..].Split("b")[0].Replace(".", "").PadRight(4, '0');
-                return int.Parse(verStr);
-            }
-            Constants.HttpClient.DefaultRequestHeaders.Add("User-Agent", "AMWin-RP");
-            var result = await Constants.HttpClient.GetStringAsync(Constants.GithubReleasesApiUrl);
-            var json = JsonDocument.Parse(result);
+        internal async Task CheckForUpdates() {
+            try {
+                static int StringVerToInt(string v) {
+                    var verStr = v[1..].Split("b")[0].Replace(".", "").PadRight(4, '0');
+                    return int.Parse(verStr);
+                }
 
-            var verLocal = Constants.ProgramVersionBase;
-            var verRemote = json.RootElement.GetProperty("name").GetString()!;
+                if (!Constants.HttpClient.DefaultRequestHeaders.UserAgent.Any()) {
+                    Constants.HttpClient.DefaultRequestHeaders.Add("User-Agent", "AMWin-RP");
+                }
 
-            var numverLocal = StringVerToInt(verLocal);
-            var numverRemote = StringVerToInt(verRemote);
+                var result = await Constants.HttpClient.GetStringAsync(Constants.GithubReleasesApiUrl);
+                using var json = JsonDocument.Parse(result);
 
-            // TODO add support for multiple beta versions (i.e. b1 and b2)
-            if (numverRemote > numverLocal || (numverRemote == numverLocal && verLocal.Contains('b') && !verRemote.Contains('b'))) {
-                Application.Current.Dispatcher.Invoke((Action)async delegate {
-                    var result = await new MessageBox {
-                        Title = Localisation.Message_AppUpdate_Title,
-                        Content = Localisation.Message_AppUpdate,
-                        IsCloseButtonEnabled = false,
-                        PrimaryButtonText = Localisation.Message_Yes,
-                        SecondaryButtonText = Localisation.Message_No
-                    }.ShowDialogAsync();
+                var verLocal = Constants.ProgramVersionBase;
+                var verRemote = json.RootElement.GetProperty("name").GetString()!;
 
-                    if (result == MessageBoxResult.Primary) {
-                        Process.Start(new ProcessStartInfo {
-                            FileName = Constants.GithubReleasesUrl,
-                            UseShellExecute = true
-                        });
-                    }
-                });
+                var numverLocal = StringVerToInt(verLocal);
+                var numverRemote = StringVerToInt(verRemote);
+
+                // TODO add support for multiple beta versions (i.e. b1 and b2)
+                if (numverRemote > numverLocal || (numverRemote == numverLocal && verLocal.Contains('b') && !verRemote.Contains('b'))) {
+                    Application.Current.Dispatcher.Invoke((Action)async delegate {
+                        var result = await new MessageBox {
+                            Title = Localisation.Message_AppUpdate_Title,
+                            Content = Localisation.Message_AppUpdate,
+                            IsCloseButtonEnabled = false,
+                            PrimaryButtonText = Localisation.Message_Yes,
+                            SecondaryButtonText = Localisation.Message_No
+                        }.ShowDialogAsync();
+
+                        if (result == MessageBoxResult.Primary) {
+                            Process.Start(new ProcessStartInfo {
+                                FileName = Constants.GithubReleasesUrl,
+                                UseShellExecute = true
+                            });
+                        }
+                    });
+                } else {
+                    logger?.Log("No AMWin-RP updates available.");
+                }
+            } catch (Exception e) {
+                logger?.Log($"Could not check for AMWin-RP updates: {e.Message}");
             }
         }
     }

--- a/AMWin-RichPresence/SettingsWindow.xaml
+++ b/AMWin-RichPresence/SettingsWindow.xaml
@@ -296,7 +296,7 @@
                                         <TextBox 
                                             x:Name="LastfmAPIKey" Margin="0 7 0 10" TextWrapping="Wrap" FontFamily="Cascadia Mono"
                                             IsEnabled="{Binding IsChecked, ElementName=CheckBox_LastfmEnable}" 
-                                            Text="{Binding Source={x:Static properties:Settings.Default}, Path=Default.LastfmAPIKey}"/>
+                                            Text="{Binding Source={x:Static properties:Settings.Default}, Path=LastfmAPIKey, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
 
                                         <TextBlock
                                             VerticalAlignment="Center" 
@@ -304,7 +304,7 @@
                                         <TextBox 
                                             x:Name="LastfmSecret" Margin="0 7 0 10" TextWrapping="Wrap" FontFamily="Cascadia Mono"
                                             IsEnabled="{Binding IsChecked, ElementName=CheckBox_LastfmEnable}" 
-                                            Text="{Binding Source={x:Static properties:Settings.Default}, Path=Default.LastfmSecret}"/>
+                                            Text="{Binding Source={x:Static properties:Settings.Default}, Path=LastfmSecret, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
 
                                         <TextBlock 
                                             VerticalAlignment="Center" 
@@ -312,7 +312,7 @@
                                         <TextBox 
                                             x:Name="LastfmUsername" Margin="0 7 0 10" TextWrapping="Wrap"
                                             IsEnabled="{Binding IsChecked, ElementName=CheckBox_LastfmEnable}" 
-                                            Text="{Binding Source={x:Static properties:Settings.Default}, Path=Default.LastfmUsername}"/>
+                                            Text="{Binding Source={x:Static properties:Settings.Default}, Path=LastfmUsername, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
 
                                         <TextBlock
                                             VerticalAlignment="Center"
@@ -350,7 +350,7 @@
                                         <TextBox 
                                             x:Name="ListenBrainzUserToken" Margin="0 7 0 10" FontFamily="Cascadia Mono"
                                             IsEnabled="{Binding IsChecked, ElementName=CheckBox_ListenBrainzEnable}" 
-                                            Text="{Binding Source={x:Static properties:Settings.Default}, Path=Default.ListenBrainzUserToken, Mode=TwoWay}" 
+                                            Text="{Binding Source={x:Static properties:Settings.Default}, Path=ListenBrainzUserToken, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                             TextWrapping="Wrap"/>               
 
                                         <Button x:Name="SaveListenBrainzCreds" Margin="0 7 0 0" VerticalAlignment="Center" HorizontalAlignment="Right" 


### PR DESCRIPTION
## Summary
- prevent startup update check failures from escaping the fire-and-forget task
- avoid adding duplicate User-Agent headers while checking releases
- bind Last.fm and ListenBrainz settings fields directly to their settings properties

## Why
The startup update check was async void, so HTTP failures after the first await could terminate the app instead of being caught by the constructor try/catch. This matches #241. The settings text boxes were also bound to Default.* under Settings.Default, so credential edits could fail to update the intended settings properties.

## Validation
- dotnet build AMWin-RichPresence.sln

Fixes #241