### PR TITLE
Song title cleaner

### DIFF
--- a/AMWin-RichPresence/App.config
+++ b/AMWin-RichPresence/App.config
@@ -37,6 +37,9 @@
             <setting name="LastfmCleanAlbumName" serializeAs="String">
                 <value>True</value>
             </setting>
+            <setting name="LastfmCleanSongName" serializeAs="String">
+                <value>True</value>
+            </setting>
             <setting name="LastfmScrobblePrimaryArtist" serializeAs="String">
                 <value>False</value>
             </setting>

--- a/AMWin-RichPresence/AppleMusicScrobbler.cs
+++ b/AMWin-RichPresence/AppleMusicScrobbler.cs
@@ -32,6 +32,18 @@ namespace AMWin_RichPresence {
 
     }
 
+    /// <summary>
+    /// Removes " (Mixed)", " [Mixed]", " (Mixed]", and " [Mixed)" from the end of song names, which Apple Music DJ Playlisted often appends to the end of the song name, and causes scrobbling issues.
+    /// </summary>
+    internal class SongCleaner {
+        private static readonly Regex SongCleanerRegex = new Regex(@"\s(\(|\[)Mixed(/]|\))$", RegexOptions.Compiled);
+
+        public static string CleanSongName(string songName) {
+            // Remove " (Mixed)", " [Mixed]", " (Mixed]", and " [Mixed)"
+            return SongCleanerRegex.Replace(songName, new MatchEvaluator((m) => { return ""; }));
+        }
+    }
+
     internal abstract class AppleMusicScrobbler<C> where C : IScrobblerCredentials {
         protected int elapsedSeconds;
         protected string? lastSongID;
@@ -90,6 +102,7 @@ namespace AMWin_RichPresence {
                 var webScraper = new AppleMusicWebScraper(info.SongName, info.SongAlbum, info.SongArtist, region);
                 var artist = Properties.Settings.Default.LastfmScrobblePrimaryArtist ? (await webScraper.GetArtistList()).FirstOrDefault(info.SongArtist) : info.SongArtist;
                 var album = Properties.Settings.Default.LastfmCleanAlbumName ? AlbumCleaner.CleanAlbumName(info.SongAlbum) : info.SongAlbum;
+                var song = Properties.Settings.Default.LastfmCleanSongName ? SongCleaner.CleanSongName(info.SongName) : info.SongName;
 
                 if (thisSongID != lastSongID) {
                     lastSongID = thisSongID;
@@ -112,7 +125,7 @@ namespace AMWin_RichPresence {
 
                         try {
                             scrobbleInProgress = true;
-                            await ScrobbleSong(artist, album, info.SongName);
+                            await ScrobbleSong(artist, album, song);
                             hasScrobbled = true;
                         } finally {
                             scrobbleInProgress = false;
@@ -123,7 +136,7 @@ namespace AMWin_RichPresence {
                 }
 
                 if (!nowPlayingSent) {
-                    nowPlayingSent = await UpdateNowPlaying(artist, album, info.SongName);
+                    nowPlayingSent = await UpdateNowPlaying(artist, album, song);
                     if (nowPlayingSent) {
                         logger?.Log($"[{serviceName} scrobbler] Updated now playing: {lastSongID}");
                     }

--- a/AMWin-RichPresence/AppleMusicScrobbler.cs
+++ b/AMWin-RichPresence/AppleMusicScrobbler.cs
@@ -36,7 +36,7 @@ namespace AMWin_RichPresence {
     /// Removes " (Mixed)", " [Mixed]", " (Mixed]", and " [Mixed)" from the end of song names, which Apple Music DJ Playlisted often appends to the end of the song name, and causes scrobbling issues.
     /// </summary>
     internal class SongCleaner {
-        private static readonly Regex SongCleanerRegex = new Regex(@"\s(\(|\[)Mixed(/]|\))$", RegexOptions.Compiled);
+        private static readonly Regex SongCleanerRegex = new Regex(@"\s(\(|\[)Mixed(\]|\))$", RegexOptions.Compiled);
 
         public static string CleanSongName(string songName) {
             // Remove " (Mixed)", " [Mixed]", " (Mixed]", and " [Mixed)"

--- a/AMWin-RichPresence/Properties/Localisation.Designer.cs
+++ b/AMWin-RichPresence/Properties/Localisation.Designer.cs
@@ -491,7 +491,25 @@ namespace AMWin_RichPresence.Properties {
                 return ResourceManager.GetString("Settings_Scrobbling_CleanAlbumName_Description", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Clean up song name.
+        /// </summary>
+        public static string Settings_Scrobbling_CleanSongName {
+            get {
+                return ResourceManager.GetString("Settings_Scrobbling_CleanSongName", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Remove extra text from song names (e.g., "(Mixed)", "[Mixed]").
+        /// </summary>
+        public static string Settings_Scrobbling_CleanSongName_Description {
+            get {
+                return ResourceManager.GetString("Settings_Scrobbling_CleanSongName_Description", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to API key.
         /// </summary>

--- a/AMWin-RichPresence/Properties/Localisation.resx
+++ b/AMWin-RichPresence/Properties/Localisation.resx
@@ -180,6 +180,12 @@
   <data name="Settings_Scrobbling_CleanAlbumName" xml:space="preserve">
     <value>Clean up album name</value>
   </data>
+  <data name="Settings_Scrobbling_CleanSongName" xml:space="preserve">
+    <value>Clean up song name</value>
+  </data>
+  <data name="Settings_Scrobbling_CleanSongName_Description" xml:space="preserve">
+    <value>Remove extra text from song names (e.g., "(Mixed)", "[Mixed]")</value>
+  </data>
   <data name="Settings_Scrobbling_ScrobblePrimaryArtist" xml:space="preserve">
     <value>Only scrobble the first artist</value>
   </data>

--- a/AMWin-RichPresence/Properties/Settings.Designer.cs
+++ b/AMWin-RichPresence/Properties/Settings.Designer.cs
@@ -145,6 +145,18 @@ namespace AMWin_RichPresence.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool LastfmCleanSongName {
+            get {
+                return ((bool)(this["LastfmCleanSongName"]));
+            }
+            set {
+                this["LastfmCleanSongName"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("False")]
         public bool LastfmScrobblePrimaryArtist {
             get {

--- a/AMWin-RichPresence/Properties/Settings.settings
+++ b/AMWin-RichPresence/Properties/Settings.settings
@@ -32,6 +32,10 @@
     <Setting Name="LastfmCleanAlbumName" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <!-- Whether to clean song names by removing " (Mixed)", " [Mixed]", " (Mixed]", and " [Mixed)" -->
+    <Setting Name="LastfmCleanSongName" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
     <Setting Name="LastfmScrobblePrimaryArtist" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>

--- a/AMWin-RichPresence/SettingsWindow.xaml
+++ b/AMWin-RichPresence/SettingsWindow.xaml
@@ -245,7 +245,17 @@
                                     Text="{x:Static properties:Localisation.Settings_Scrobbling_CleanAlbumName_Description}"/>
 
                                 <CheckBox 
-                                    x:Name="CheckBox_LastfmScrobblePrimary" Margin="0 2 0 0" 
+                                    x:Name="CheckBox_LastfmCleanSongName"
+                                    IsChecked="{Binding Source={x:Static properties:Settings.Default}, Path=LastfmCleanSongName, Mode=TwoWay}" 
+                                    Click="CheckBox_LastfmCleanSongName_Click" 
+                                    Content="{x:Static properties:Localisation.Settings_Scrobbling_CleanSongName}"/>
+                                <TextBlock 
+                                    Margin="40 0 0 10" FontSize="12"  VerticalAlignment="Center" TextWrapping="Wrap"
+                                    Text="{x:Static properties:Localisation.Settings_Scrobbling_CleanSongName_Description}"/>
+
+                                <CheckBox 
+                                    x:Name="CheckBox_LastfmScrobblePrimary" 
+                                    Margin="0 2 0 0" 
                                     IsChecked="{Binding Source={x:Static properties:Settings.Default}, Path=LastfmScrobblePrimaryArtist, Mode=TwoWay}" 
                                     Click="CheckBox_LastfmScrobblePrimary_Click" 
                                     Content="{x:Static properties:Localisation.Settings_Scrobbling_ScrobblePrimaryArtist}"/>

--- a/AMWin-RichPresence/SettingsWindow.xaml.cs
+++ b/AMWin-RichPresence/SettingsWindow.xaml.cs
@@ -245,6 +245,10 @@ namespace AMWin_RichPresence {
             SaveSettings();
         }
 
+        private void CheckBox_LastfmCleanSongName_Click(object sender, RoutedEventArgs e) {
+            SaveSettings();
+        }
+
         private void CheckBox_LastfmScrobblePrimary_Click(object sender, RoutedEventArgs e) {
             SaveSettings();
         }


### PR DESCRIPTION
Added a configuration and implemented a method to cleanse the track title of the `(Mixed)` or `[Mixed]` appended to end of tracks in DJ sets.