### PR TITLE
Add setting to choose which Discord client receives Rich Presence (Stable/PTB/Canary)

### DIFF
--- a/AMWin-RichPresence/App.xaml.cs
+++ b/AMWin-RichPresence/App.xaml.cs
@@ -115,7 +115,8 @@ namespace AMWin_RichPresence {
             // start Discord RPC
             var statusDisplayOptions = (AppleMusicDiscordClient.RPStatusDisplayOptions)AMWin_RichPresence.Properties.Settings.Default.RPDisplayChoice;
             var classicalComposerAsArtist = AMWin_RichPresence.Properties.Settings.Default.ClassicalComposerAsArtist;
-            discordClient = new(Constants.DiscordClientID, enabled: false, statusDisplayOptions: statusDisplayOptions, logger: logger);
+            var preferredDiscordClient = (DiscordClientType)AMWin_RichPresence.Properties.Settings.Default.DiscordClientPreference;
+            discordClient = new(Constants.DiscordClientID, enabled: false, statusDisplayOptions: statusDisplayOptions, logger: logger, preferredClient: preferredDiscordClient);
 
             // start Last.FM scrobbler
             var amRegion = AMWin_RichPresence.Properties.Settings.Default.AppleMusicRegion;
@@ -183,6 +184,10 @@ namespace AMWin_RichPresence {
 
         internal void UpdateRPStatusDisplay(AppleMusicDiscordClient.RPStatusDisplayOptions newVal) {
             discordClient.statusDisplayOptions = newVal;
+        }
+
+        internal void UpdateDiscordClientPreference(DiscordClientType newClient) {
+            discordClient.SetPreferredClient(newClient);
         }
 
         internal async Task<bool> UpdateLastfmCreds() {

--- a/AMWin-RichPresence/AppleMusicDiscordClient.cs
+++ b/AMWin-RichPresence/AppleMusicDiscordClient.cs
@@ -22,17 +22,20 @@ internal class AppleMusicDiscordClient {
     Logger? logger;
     int maxStringLength = 127;
     string? songLyrics = null;
+    DiscordClientType preferredClient;
 
     public AppleMusicDiscordClient(
         string discordClientID,
         bool enabled = true,
         RPStatusDisplayOptions statusDisplayOptions = RPStatusDisplayOptions.Artist,
-        Logger? logger = null
+        Logger? logger = null,
+        DiscordClientType preferredClient = DiscordClientType.Auto
     ) {
         this.discordClientID = discordClientID;
         this.enabled = enabled;
         this.statusDisplayOptions = statusDisplayOptions;
         this.logger = logger;
+        this.preferredClient = preferredClient;
 
         if (enabled) {
             InitClient();
@@ -169,8 +172,27 @@ internal class AppleMusicDiscordClient {
         client?.ClearPresence();
         DeinitClient();
     }
+    public void SetPreferredClient(DiscordClientType newClient) {
+        if (preferredClient == newClient) {
+            return;
+        }
+        preferredClient = newClient;
+
+        if (enabled) {
+            client?.ClearPresence();
+            DeinitClient();
+            InitClient();
+        }
+    }
     private void InitClient() {
-        client = new DiscordRpcClient(discordClientID, logger: logger);
+        int pipe = -1;
+        if (preferredClient != DiscordClientType.Auto) {
+            var resolved = DiscordPipeFinder.FindPipeForClient(preferredClient, logger);
+            if (resolved != null) {
+                pipe = resolved.Value;
+            }
+        }
+        client = new DiscordRpcClient(discordClientID, pipe: pipe, logger: logger);
         client.Initialize();
     }
     private void DeinitClient() {

--- a/AMWin-RichPresence/DiscordPipeFinder.cs
+++ b/AMWin-RichPresence/DiscordPipeFinder.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Pipes;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+namespace AMWin_RichPresence {
+
+    public enum DiscordClientType {
+        Auto = 0,
+        Stable = 1,
+        PTB = 2,
+        Canary = 3
+    }
+
+    internal static class DiscordPipeFinder {
+
+        const int PipeConnectTimeoutMs = 100;
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        static extern bool GetNamedPipeServerProcessId(SafePipeHandle Pipe, out uint ServerProcessId);
+
+        public static string? ProcessNameFor(DiscordClientType client) {
+            return client switch {
+                DiscordClientType.Stable => "Discord",
+                DiscordClientType.PTB    => "DiscordPTB",
+                DiscordClientType.Canary => "DiscordCanary",
+                _ => null
+            };
+        }
+
+        public static int? FindPipeForClient(DiscordClientType client, Logger? logger = null) {
+            var wantedProcess = ProcessNameFor(client);
+            if (wantedProcess == null) {
+                return null;
+            }
+
+            string[] pipeNames;
+            try {
+                pipeNames = Directory.GetFiles(@"\\.\pipe\", "discord-ipc-*")
+                    .Select(Path.GetFileName)
+                    .Where(name => name != null)
+                    .ToArray()!;
+            } catch (Exception ex) {
+                logger?.Log($"Could not enumerate Discord IPC pipes: {ex.Message}");
+                return null;
+            }
+
+            foreach (var pipeName in pipeNames) {
+                var owner = GetPipeServerProcessName(pipeName, logger);
+                if (owner != null && string.Equals(owner, wantedProcess, StringComparison.OrdinalIgnoreCase)) {
+                    var pipeNumber = ParsePipeNumber(pipeName);
+                    if (pipeNumber != null) {
+                        logger?.Log($"Matched Discord client '{client}' ({wantedProcess}) to {pipeName}");
+                        return pipeNumber;
+                    }
+                }
+            }
+
+            logger?.Log($"No running '{wantedProcess}' IPC pipe found; falling back to autodetect");
+            return null;
+        }
+
+        static string? GetPipeServerProcessName(string pipeName, Logger? logger) {
+            try {
+                using var pipe = new NamedPipeClientStream(".", pipeName, PipeDirection.In);
+                pipe.Connect(PipeConnectTimeoutMs);
+
+                if (!GetNamedPipeServerProcessId(pipe.SafePipeHandle, out uint serverPid)) {
+                    return null;
+                }
+
+                using var process = Process.GetProcessById((int)serverPid);
+                return process.ProcessName;
+            } catch (Exception ex) {
+                logger?.Log($"Could not inspect pipe {pipeName}: {ex.Message}");
+                return null;
+            }
+        }
+
+        static int? ParsePipeNumber(string pipeName) {
+            var dash = pipeName.LastIndexOf('-');
+            if (dash >= 0 && dash < pipeName.Length - 1
+                && int.TryParse(pipeName.AsSpan(dash + 1), out var number)) {
+                return number;
+            }
+            return null;
+        }
+    }
+}

--- a/AMWin-RichPresence/Properties/Localisation.resx
+++ b/AMWin-RichPresence/Properties/Localisation.resx
@@ -150,6 +150,24 @@
   <data name="Settings_Discord_UserStatusDisplay" xml:space="preserve">
     <value>Show Discord status as</value>
   </data>
+  <data name="Settings_Discord_ClientChoice" xml:space="preserve">
+    <value>Send Rich Presence to</value>
+  </data>
+  <data name="Settings_Discord_ClientChoice_Description" xml:space="preserve">
+    <value>Choose which Discord app receives Rich Presence when you have more than one running (e.g. Stable and Canary). Leave on Automatic if you only use one.</value>
+  </data>
+  <data name="Settings_Discord_ClientChoice_Auto" xml:space="preserve">
+    <value>Automatic (any running client)</value>
+  </data>
+  <data name="Settings_Discord_ClientChoice_Stable" xml:space="preserve">
+    <value>Discord (Stable)</value>
+  </data>
+  <data name="Settings_Discord_ClientChoice_PTB" xml:space="preserve">
+    <value>Discord PTB</value>
+  </data>
+  <data name="Settings_Discord_ClientChoice_Canary" xml:space="preserve">
+    <value>Discord Canary</value>
+  </data>
   <data name="Settings_Discord_UserStatusDisplay_Artist" xml:space="preserve">
     <value>Artist name</value>
   </data>

--- a/AMWin-RichPresence/Properties/Settings.Designer.cs
+++ b/AMWin-RichPresence/Properties/Settings.Designer.cs
@@ -322,5 +322,17 @@ namespace AMWin_RichPresence.Properties {
                 this["Language"] = value;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("0")]
+        public int DiscordClientPreference {
+            get {
+                return ((int)(this["DiscordClientPreference"]));
+            }
+            set {
+                this["DiscordClientPreference"] = value;
+            }
+        }
     }
 }

--- a/AMWin-RichPresence/Properties/Settings.settings
+++ b/AMWin-RichPresence/Properties/Settings.settings
@@ -78,5 +78,8 @@
     <Setting Name="Language" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
+    <Setting Name="DiscordClientPreference" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">0</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/AMWin-RichPresence/SettingsWindow.xaml
+++ b/AMWin-RichPresence/SettingsWindow.xaml
@@ -188,6 +188,28 @@
                                     </ComboBox>
                                 </StackPanel>
 
+                                <StackPanel Orientation="Horizontal" Margin="10 7 0 2">
+                                    <TextBlock
+                                        x:Name="TextBlock_DiscordClientLabel"
+                                        VerticalAlignment="Center"
+                                        Margin="0 0 10 2"
+                                        Text="Send Rich Presence to"/>
+                                    <ComboBox
+                                        x:Name="ComboBox_DiscordClient"
+                                        Width="245"
+                                        IsEnabled="{Binding IsChecked, ElementName=CheckBox_EnableDiscordRP}"
+                                        SelectionChanged="ComboBox_DiscordClient_SelectionChanged">
+                                        <ComboBoxItem x:Name="ComboBoxItem_DiscordClientAuto"/>
+                                        <ComboBoxItem x:Name="ComboBoxItem_DiscordClientStable"/>
+                                        <ComboBoxItem x:Name="ComboBoxItem_DiscordClientPTB"/>
+                                        <ComboBoxItem x:Name="ComboBoxItem_DiscordClientCanary"/>
+                                    </ComboBox>
+                                </StackPanel>
+                                <TextBlock
+                                    x:Name="TextBlock_DiscordClientDescription"
+                                    Margin="10 5 0 10" FontSize="12" VerticalAlignment="Center" TextWrapping="Wrap"
+                                    Text="Choose which Discord app receives Rich Presence when you have more than one running."/>
+
                                 <!-- Discord RP settings: Lyrics (experimental) -->
                                 <ui:Card Margin="0 15 0 5">
                                     <StackPanel>

--- a/AMWin-RichPresence/SettingsWindow.xaml.cs
+++ b/AMWin-RichPresence/SettingsWindow.xaml.cs
@@ -20,6 +20,7 @@ namespace AMWin_RichPresence {
     /// </summary>
     public partial class SettingsWindow : FluentWindow {
         private bool isLanguageSelectorInitialized;
+        private bool isDiscordClientSelectorInitialized;
 
         private bool amRegionValid {
             get { return Constants.ValidAppleMusicRegions.Contains(AppleMusicRegion.Text.ToLower()); }
@@ -30,6 +31,7 @@ namespace AMWin_RichPresence {
             SystemThemeWatcher.Watch(this);
             InitializeComponent();
             InitializeLanguageSelector();
+            InitializeDiscordClientSelector();
 
             string imagePath = IsDarkMode()
                 ? "/Resources/GitHub_Invertocat_White.png"
@@ -94,6 +96,23 @@ namespace AMWin_RichPresence {
             };
 
             isLanguageSelectorInitialized = true;
+        }
+
+        private void InitializeDiscordClientSelector() {
+            TextBlock_DiscordClientLabel.Text = GetLocalisedString("Settings_Discord_ClientChoice", "Send Rich Presence to");
+            TextBlock_DiscordClientDescription.Text = GetLocalisedString("Settings_Discord_ClientChoice_Description", "Choose which Discord app receives Rich Presence when you have more than one running (e.g. Stable and Canary). Leave on Automatic if you only use one.");
+            ComboBoxItem_DiscordClientAuto.Content = GetLocalisedString("Settings_Discord_ClientChoice_Auto", "Automatic (any running client)");
+            ComboBoxItem_DiscordClientStable.Content = GetLocalisedString("Settings_Discord_ClientChoice_Stable", "Discord (Stable)");
+            ComboBoxItem_DiscordClientPTB.Content = GetLocalisedString("Settings_Discord_ClientChoice_PTB", "Discord PTB");
+            ComboBoxItem_DiscordClientCanary.Content = GetLocalisedString("Settings_Discord_ClientChoice_Canary", "Discord Canary");
+
+            var selectedIndex = Properties.Settings.Default.DiscordClientPreference;
+            if (selectedIndex < 0 || selectedIndex >= ComboBox_DiscordClient.Items.Count) {
+                selectedIndex = 0;
+            }
+            ComboBox_DiscordClient.SelectedIndex = selectedIndex;
+
+            isDiscordClientSelectorInitialized = true;
         }
 
         private static string GetLocalisedString(string key, string fallback) {
@@ -167,6 +186,16 @@ namespace AMWin_RichPresence {
             var newOption = AppleMusicDiscordClient.StatusDisplayOptionFromIndex(ComboBox_RPDisplayChoice.SelectedIndex);
             ((App)Application.Current).UpdateRPStatusDisplay(newOption);
             SaveSettings();
+        }
+
+        private void ComboBox_DiscordClient_SelectionChanged(object sender, SelectionChangedEventArgs e) {
+            if (!isDiscordClientSelectorInitialized) {
+                return;
+            }
+            var selectedIndex = ComboBox_DiscordClient.SelectedIndex;
+            Properties.Settings.Default.DiscordClientPreference = selectedIndex;
+            SaveSettings();
+            ((App)Application.Current).UpdateDiscordClientPreference((DiscordClientType)selectedIndex);
         }
 
         private void CheckBox_EnableSyncLyrics_Click(object sender, RoutedEventArgs e) {


### PR DESCRIPTION
## What this does

Adds an optional **"Send Rich Presence to"** dropdown to the Discord settings that lets the user pick which Discord client Rich Presence is sent to:

- **Automatic (any running client)** — default, current behaviour is completely unchanged
- **Discord (Stable)**
- **Discord PTB**
- **Discord Canary**

## Why

When more than one Discord client is running (e.g. Stable + Canary), the RPC library's pipe autodetection connects to whichever `discord-ipc-N` pipe answers first, which is often not the client the user is actually using. There's currently no way to steer the presence to a specific client. This has come up a few times:

- #124 – Multiple Discord Problem
- #112 – Failing to connect / RPC not working when running both Canary and Stable at the same time

## How it works

Every Discord flavour uses the same `discord-ipc-0` … `discord-ipc-9` pipe naming, and the slot a client ends up on depends only on launch order — so a flavour can't be mapped to a fixed pipe number.

Instead, when the user pins a specific client, `DiscordPipeFinder` enumerates the existing `discord-ipc-*` pipes and asks Windows which process owns each pipe's server end (`GetNamedPipeServerProcessId`). Matching that PID's process name (`Discord` / `DiscordPTB` / `DiscordCanary`) gives a deterministic flavour → pipe mapping, and that pipe number is passed straight to `DiscordRpcClient`. If the chosen client isn't running, it falls back to the existing autodetection so nothing breaks.

## Notes

- **Fully opt-in.** The default (`Auto`) keeps the exact current behaviour, so single-client users see no change.
- Changing the dropdown reconnects live, and clears the presence on the previously targeted client so it doesn't linger there.
- Adds one setting: `DiscordClientPreference` (int, default `0`).
- English UI strings were added to `Localisation.resx`; translations are welcome — the code falls back to English until they're added.

Built with 0 warnings / 0 errors on Windows 11 with .NET 10. I also verified the pipe-owner detection against a real running client — DiscordPTB, which happened to be on `discord-ipc-2` (not `-0`), was correctly identified.
