### PR TITLE
fix: Rich Presence not displaying for single-character artist names

### DIFF
--- a/AMWin-RichPresence/AppleMusicDiscordClient.cs
+++ b/AMWin-RichPresence/AppleMusicDiscordClient.cs
@@ -71,6 +71,11 @@ internal class AppleMusicDiscordClient {
             songAlbum += "\u0000";
         }
 
+        // hack to show 1-character artist names
+        while (songArtist.Length < 2) {
+            songArtist += "\u0000";
+        }
+
         // pick the subtitle format to show
         var statusDisplay = StatusDisplayType.Details;
         switch (statusDisplayOptions) {


### PR DESCRIPTION
## Problem

Songs by artists whose name is a single character (e.g. 嵐 / Arashi) never show Rich Presence. Discord requires activity strings to be at least 2 characters, so when the artist name is only 1 character the `State` field is rejected and the whole presence silently fails to display.

This is the same failure mode as #145, which was fixed for 1-character **album** names. The same null-padding hack also exists for 1-character **song** names, but the artist name (`State`) was never covered.

## Fix

Apply the existing null-padding hack to `songArtist` as well:

```cs
// hack to show 1-character artist names
while (songArtist.Length < 2) {
    songArtist += "\u0000";
}
```

## Testing

Verified locally: playing "Five" by 嵐 previously showed no Rich Presence at all; with this change the presence displays correctly (song, artist, album art, timestamps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
